### PR TITLE
rise.lowering_unit

### DIFF
--- a/mlir/include/mlir/Dialect/Rise/EDSC/Builders.h
+++ b/mlir/include/mlir/Dialect/Rise/EDSC/Builders.h
@@ -77,6 +77,7 @@ void out(Value writeTo, Value result);
 Value embed(Type result, ValueRange exposedValues,
             function_ref<Value(MutableArrayRef<BlockArgument>)> bodyBuilder);
 void rise_return(Value returnValue);
+void lowering_unit(function_ref<void()> bodyBuilder);
 
 // Patterns
 Value mapSeq(DataType resultElemType, function_ref<Value(BlockArgument)> bodyBuilder,

--- a/mlir/include/mlir/Dialect/Rise/EDSC/HighLevel.h
+++ b/mlir/include/mlir/Dialect/Rise/EDSC/HighLevel.h
@@ -41,10 +41,12 @@ void makeRiseProgram(Value input0, Value input1, Value input2, Value input3, Val
 Value matrix_multiplication(int M, int N, int K, Value A, Value B);
 Value conv2D(Value input, Value kernel);
 Value conv2D(Value input, Value kernel, int padl, int padr, int padt, int padb);
+Value conv2DSeparated(Value input, Value kernelH, Value kernelV, int padl,
+                      int padr, int padt, int padb);
 Value conv2DTF(Value input, Value kernel);
 Value stencil(int N, int windowSize, int step, Value input);
 Value stencil2D(int M, int N, int outerWindowSize, int outerStep,
-               int innerWindowSize, int innerStep, Value input);
+                int innerWindowSize, int innerStep, Value input);
 
 // utilities
 void generateTest(int dims, ArrayRef<int64_t> inSizes,
@@ -52,6 +54,9 @@ void generateTest(int dims, ArrayRef<int64_t> inSizes,
 void generateTest(int dims, ArrayRef<int64_t> inSizesA,
                   ArrayRef<int64_t> inSizesB, ArrayRef<int64_t> outSizes,
                   FuncOp riseFun = nullptr);
+void generateTest(int dims, ArrayRef<int64_t> inSizesA,
+                  ArrayRef<int64_t> inSizesB, ArrayRef<int64_t> inSizesC,
+                  ArrayRef<int64_t> outSizes, FuncOp riseFun);
 } // namespace highlevel
 } // namespace edsc
 } // namespace mlir

--- a/mlir/include/mlir/Dialect/Rise/EDSC/HighLevel.h
+++ b/mlir/include/mlir/Dialect/Rise/EDSC/HighLevel.h
@@ -24,25 +24,46 @@
 #include "mlir/IR/Types.h"
 
 using namespace mlir::rise;
+using namespace mlir::edsc::type;
+using namespace mlir::edsc::op;
 
 namespace mlir {
 namespace edsc {
 namespace highlevel {
 
+// clang-format off
+void makeRiseProgram(Value input, Value output, function_ref<Value(Value)> bodyBuilder, bool loweringUnitPresent = false);
+void makeRiseProgram(Value input0, Value input1, Value output, function_ref<Value(Value, Value)> bodyBuilder, bool loweringUnitPresent = false);
+void makeRiseProgram(Value input0, Value input1, Value input2, Value output, function_ref<Value(Value, Value, Value)> bodyBuilder, bool loweringUnitPresent = false);
+// clang-format on
+
+// TODO: this works fine for the inputs at the end but not for the lambda. When
+// this is called its type can never be deduced. Any ideas?
+// template<typename ...Args>
+// void makeRiseProgram(Value output, function_ref<Value(Value, Args...)>
+// bodyBuilder, Value input, Args... inputs) {
+//
+//  makeRiseProgram(output, [&](auto... args){ bodyBuilder(input, args...); },
+//  inputs...);
+//
+//
+//  // [&](Value ){return bodyBuilder(input0, inputs...);});
+//  return;
+//}
+
 void matrix_multiplication(int M, int N, int K, Value A, Value B, Value C);
 Value conv2D(Value input, Value kernel);
 Value conv2D(Value input, Value kernel, int padl, int padr, int padt, int padb);
 void stencil(int N, int windowSize, int step, Value input, Value output);
-void stencil2D(int M, int N, int outerWindowSize,
-                                      int outerStep, int innerWindowSize, int innerStep,
-                                      Value input, Value output);
+void stencil2D(int M, int N, int outerWindowSize, int outerStep,
+               int innerWindowSize, int innerStep, Value input, Value output);
 
 // utilities
 void generateTest(int dims, ArrayRef<int64_t> inSizes,
                   ArrayRef<int64_t> outSizes, FuncOp riseFun = nullptr);
-void generateTest(int dims, ArrayRef<int64_t> inSizesA, ArrayRef<int64_t> inSizesB,
-                                         ArrayRef<int64_t> outSizes,
-                                         FuncOp riseFun = nullptr);
+void generateTest(int dims, ArrayRef<int64_t> inSizesA,
+                  ArrayRef<int64_t> inSizesB, ArrayRef<int64_t> outSizes,
+                  FuncOp riseFun = nullptr);
 } // namespace highlevel
 } // namespace edsc
 } // namespace mlir

--- a/mlir/include/mlir/Dialect/Rise/EDSC/HighLevel.h
+++ b/mlir/include/mlir/Dialect/Rise/EDSC/HighLevel.h
@@ -32,6 +32,7 @@ namespace highlevel {
 void matrix_multiplication(int M, int N, int K, Value A, Value B, Value C);
 Value conv2D(Value input, Value kernel);
 Value conv2D(Value input, Value kernel, int padl, int padr, int padt, int padb);
+Value conv2DTF(Value input, Value kernel);
 void stencil(int N, int windowSize, int step, Value input, Value output);
 void stencil2D(int M, int N, int outerWindowSize,
                                       int outerStep, int innerWindowSize, int innerStep,

--- a/mlir/include/mlir/Dialect/Rise/EDSC/HighLevel.h
+++ b/mlir/include/mlir/Dialect/Rise/EDSC/HighLevel.h
@@ -31,6 +31,7 @@ namespace highlevel {
 
 void matrix_multiplication(int M, int N, int K, Value A, Value B, Value C);
 Value conv2D(Value input, Value kernel);
+Value conv2D(Value input, Value kernel, int padl, int padr, int padt, int padb);
 void stencil(int N, int windowSize, int step, Value input, Value output);
 void stencil2D(int M, int N, int outerWindowSize,
                                       int outerStep, int innerWindowSize, int innerStep,

--- a/mlir/include/mlir/Dialect/Rise/IR/Rise.td
+++ b/mlir/include/mlir/Dialect/Rise/IR/Rise.td
@@ -89,6 +89,7 @@ def LambdaOp : Rise_Op<"lambda", [SingleBlockImplicitTerminator<"ReturnOp">]> {
                             "&, Location, MutableArrayRef<BlockArgument>)> "
                             "bodyBuilder = nullptr">];
   let parser = [{ return parse$cppClass(parser, result); }];
+  let verifier = [{ return verify$cppClass(*this); }];
 }
 
 def ApplyOp : Rise_Op<"apply"> {
@@ -113,7 +114,7 @@ def ApplyOp : Rise_Op<"apply"> {
 def LoweringUnitOp
     : Rise_Op<"lowering_unit", [SingleBlockImplicitTerminator<"ReturnOp">]> {
   let summary = "rise lowering unit";
-  let description = "Represents a region of RISE operations to be lowered "
+  let description = "Represents a unit of RISE operations to be lowered "
                     "independently of other RISE operations.";
   let regions = (region SizedRegion<1> : $region);
   let skipDefaultBuilders = 1;

--- a/mlir/include/mlir/Dialect/Rise/IR/Rise.td
+++ b/mlir/include/mlir/Dialect/Rise/IR/Rise.td
@@ -116,6 +116,10 @@ def LoweringUnitOp
   let description = "Represents a region of RISE operations to be lowered "
                     "independently of other RISE operations.";
   let regions = (region SizedRegion<1> : $region);
+  let skipDefaultBuilders = 1;
+  let builders = [OpBuilder<"OpBuilder &builder, OperationState &result, "
+                            "function_ref<void(OpBuilder &, Location)> "
+                            "bodyBuilder">];
   let parser = [{ return parse$cppClass(parser, result); }];
 }
 

--- a/mlir/include/mlir/Dialect/Rise/IR/Rise.td
+++ b/mlir/include/mlir/Dialect/Rise/IR/Rise.td
@@ -110,6 +110,14 @@ def ApplyOp : Rise_Op<"apply"> {
 // Rise Operations: Interoperability
 //===----------------------------------------------------------------------===//
 
+def LoweringUnitOp : Rise_Op<"lowering_unit", [SingleBlockImplicitTerminator<"ReturnOp">]> {
+  let summary = "rise lowering unit";
+  let description = "Represents a region of RISE operations to be lowered "
+                    "independently of other RISE operations.";
+  let regions = (region SizedRegion<1> : $region);
+  let parser = [{ return parse$cppClass(parser, result); }];
+}
+
 def InOp : Rise_Op<"in"> {
   let summary = "rise in";
   let description =

--- a/mlir/include/mlir/Dialect/Rise/IR/Rise.td
+++ b/mlir/include/mlir/Dialect/Rise/IR/Rise.td
@@ -110,7 +110,8 @@ def ApplyOp : Rise_Op<"apply"> {
 // Rise Operations: Interoperability
 //===----------------------------------------------------------------------===//
 
-def LoweringUnitOp : Rise_Op<"lowering_unit", [SingleBlockImplicitTerminator<"ReturnOp">]> {
+def LoweringUnitOp
+    : Rise_Op<"lowering_unit", [SingleBlockImplicitTerminator<"ReturnOp">]> {
   let summary = "rise lowering unit";
   let description = "Represents a region of RISE operations to be lowered "
                     "independently of other RISE operations.";
@@ -473,10 +474,23 @@ def JoinAccIntermediateOp : Rise_Op<"codegen.joinAcc"> {
 }
 
 def TransposeIntermediateOp : Rise_Op<"codegen.transpose"> {
-  let summary = "rise snd_interm";
+  let summary = "rise transpose_interm";
   let description =
       "The codegen.transpose operation is the codegen equivalent of "
       "the transpose operation.";
+  let arguments = (ins AnyType
+                   : $value, NatAttr
+                   : $n, NatAttr
+                   : $m, DataTypeAttr
+                   : $t);
+  let results = (outs AnyType : $output);
+}
+
+def TransposeAccIntermediateOp : Rise_Op<"codegen.transposeStore"> {
+  let summary = "rise transposeAcc_interm";
+  let description =
+      "The codegen.transpose operation is the codegen equivalent of "
+      "the transpose operation used in a writing access.";
   let arguments = (ins AnyType
                    : $value, NatAttr
                    : $n, NatAttr
@@ -513,8 +527,8 @@ def PadIntermediateOp : Rise_Op<"codegen.pad"> {
 
 def AssignOp : Rise_Op<"codegen.assign"> {
   let summary = "rise assign";
-  let description =
-      "The codegen.assign operation models an assignment of value to assignee.";
+  let description = "The codegen.assign operation models an assignment of "
+                    "value to assignee.";
   let arguments = (ins AnyType : $value, AnyType : $assignee);
 }
 

--- a/mlir/include/mlir/Dialect/Rise/invoke.hpp
+++ b/mlir/include/mlir/Dialect/Rise/invoke.hpp
@@ -1,0 +1,280 @@
+/*******************************************************************************
+ * This file is part of the "https://github.com/blackmatov/invoke.hpp"
+ * For conditions of distribution and use, see copyright notice in LICENSE.md
+ * Copyright (C) 2018-2020, by Matvey Cherevko (blackmatov@gmail.com)
+ ******************************************************************************/
+
+#pragma once
+
+#include <tuple>
+#include <utility>
+#include <functional>
+#include <type_traits>
+
+#define INVOKE_HPP_NOEXCEPT_DECLTYPE_RETURN(...) \
+    noexcept(noexcept(__VA_ARGS__)) -> decltype (__VA_ARGS__) { return __VA_ARGS__; }
+
+//
+// void_t
+//
+
+namespace invoke_hpp
+{
+    namespace impl
+    {
+        template < typename... Args >
+        struct make_void {
+            using type = void;
+        };
+    }
+
+    template < typename... Args >
+    using void_t = typename impl::make_void<Args...>::type;
+}
+
+//
+// integer_sequence
+//
+
+namespace invoke_hpp
+{
+    template < typename T, T... Ints >
+    struct integer_sequence {
+        using value_type = T;
+        static constexpr std::size_t size() noexcept { return sizeof...(Ints); }
+    };
+
+    template < std::size_t... Ints >
+    using index_sequence = integer_sequence<std::size_t, Ints...>;
+
+    namespace impl
+    {
+        template < typename T, std::size_t N, T... Ints >
+        struct make_integer_sequence_impl
+        : make_integer_sequence_impl<T, N - 1, N - 1, Ints...> {};
+
+        template < typename T, T... Ints >
+        struct make_integer_sequence_impl<T, 0, Ints...>
+        : integer_sequence<T, Ints...> {};
+    }
+
+    template < typename T, std::size_t N >
+    using make_integer_sequence = impl::make_integer_sequence_impl<T, N>;
+
+    template < std::size_t N >
+    using make_index_sequence = make_integer_sequence<std::size_t, N>;
+
+    template < typename... Ts >
+    using index_sequence_for = make_index_sequence<sizeof...(Ts)>;
+}
+
+//
+// is_reference_wrapper
+//
+
+namespace invoke_hpp
+{
+    namespace impl
+    {
+        template < typename T >
+        struct is_reference_wrapper_impl
+        : std::false_type {};
+
+        template < typename U >
+        struct is_reference_wrapper_impl<std::reference_wrapper<U>>
+        : std::true_type {};
+    }
+
+    template < typename T >
+    struct is_reference_wrapper
+    : impl::is_reference_wrapper_impl<typename std::remove_cv<T>::type> {};
+}
+
+//
+// invoke
+//
+
+namespace invoke_hpp
+{
+    namespace impl
+    {
+        //
+        // invoke_member_object_impl
+        //
+
+        template
+        <
+            typename Base, typename F, typename Derived,
+            typename std::enable_if<std::is_base_of<Base, typename std::decay<Derived>::type>::value, int>::type = 0
+        >
+        constexpr auto invoke_member_object_impl(F Base::* f, Derived&& ref)
+        INVOKE_HPP_NOEXCEPT_DECLTYPE_RETURN(
+            std::forward<Derived>(ref).*f)
+
+        template
+        <
+            typename Base, typename F, typename RefWrap,
+            typename std::enable_if<is_reference_wrapper<typename std::decay<RefWrap>::type>::value, int>::type = 0
+        >
+        constexpr auto invoke_member_object_impl(F Base::* f, RefWrap&& ref)
+        INVOKE_HPP_NOEXCEPT_DECLTYPE_RETURN(
+            ref.get().*f)
+
+        template
+        <
+            typename Base, typename F, typename Pointer,
+            typename std::enable_if<
+                !std::is_base_of<Base, typename std::decay<Pointer>::type>::value &&
+                !is_reference_wrapper<typename std::decay<Pointer>::type>::value
+            , int>::type = 0
+        >
+        constexpr auto invoke_member_object_impl(F Base::* f, Pointer&& ptr)
+        INVOKE_HPP_NOEXCEPT_DECLTYPE_RETURN(
+            (*std::forward<Pointer>(ptr)).*f)
+
+        //
+        // invoke_member_function_impl
+        //
+
+        template
+        <
+            typename Base, typename F, typename Derived, typename... Args,
+            typename std::enable_if<std::is_base_of<Base, typename std::decay<Derived>::type>::value, int>::type = 0
+        >
+        constexpr auto invoke_member_function_impl(F Base::* f, Derived&& ref, Args&&... args)
+        INVOKE_HPP_NOEXCEPT_DECLTYPE_RETURN(
+            (std::forward<Derived>(ref).*f)(std::forward<Args>(args)...))
+
+        template
+        <
+            typename Base, typename F, typename RefWrap, typename... Args,
+            typename std::enable_if<is_reference_wrapper<typename std::decay<RefWrap>::type>::value, int>::type = 0
+        >
+        constexpr auto invoke_member_function_impl(F Base::* f, RefWrap&& ref, Args&&... args)
+        INVOKE_HPP_NOEXCEPT_DECLTYPE_RETURN(
+            (ref.get().*f)(std::forward<Args>(args)...))
+
+        template
+        <
+            typename Base, typename F, typename Pointer, typename... Args,
+            typename std::enable_if<
+                !std::is_base_of<Base, typename std::decay<Pointer>::type>::value &&
+                !is_reference_wrapper<typename std::decay<Pointer>::type>::value
+            , int>::type = 0
+        >
+        constexpr auto invoke_member_function_impl(F Base::* f, Pointer&& ptr, Args&&... args)
+        INVOKE_HPP_NOEXCEPT_DECLTYPE_RETURN(
+            ((*std::forward<Pointer>(ptr)).*f)(std::forward<Args>(args)...))
+    }
+
+    template
+    <
+        typename F, typename... Args,
+        typename std::enable_if<!std::is_member_pointer<typename std::decay<F>::type>::value, int>::type = 0
+    >
+    constexpr auto invoke(F&& f, Args&&... args)
+    INVOKE_HPP_NOEXCEPT_DECLTYPE_RETURN(
+        std::forward<F>(f)(std::forward<Args>(args)...))
+
+    template
+    <
+        typename F, typename T,
+        typename std::enable_if<std::is_member_object_pointer<typename std::decay<F>::type>::value, int>::type = 0
+    >
+    constexpr auto invoke(F&& f, T&& t)
+    INVOKE_HPP_NOEXCEPT_DECLTYPE_RETURN(
+        impl::invoke_member_object_impl(std::forward<F>(f), std::forward<T>(t)))
+
+    template
+    <
+        typename F, typename... Args,
+        typename std::enable_if<std::is_member_function_pointer<typename std::decay<F>::type>::value, int>::type = 0
+    >
+    constexpr auto invoke(F&& f, Args&&... args)
+    INVOKE_HPP_NOEXCEPT_DECLTYPE_RETURN(
+        impl::invoke_member_function_impl(std::forward<F>(f), std::forward<Args>(args)...))
+}
+
+//
+// invoke_result
+//
+
+namespace invoke_hpp
+{
+    namespace impl
+    {
+        struct invoke_result_impl_tag {};
+
+        template < typename Void, typename F, typename... Args >
+        struct invoke_result_impl {};
+
+        template < typename F, typename... Args >
+        struct invoke_result_impl<void_t<invoke_result_impl_tag, decltype(invoke_hpp::invoke(std::declval<F>(), std::declval<Args>()...))>, F, Args...> {
+            using type = decltype(invoke_hpp::invoke(std::declval<F>(), std::declval<Args>()...));
+        };
+    }
+
+    template < typename F, typename... Args >
+    struct invoke_result
+    : impl::invoke_result_impl<void, F, Args...> {};
+
+    template < typename F, typename... Args >
+    using invoke_result_t = typename invoke_result<F, Args...>::type;
+}
+
+//
+// is_invocable
+//
+
+namespace invoke_hpp
+{
+    namespace impl
+    {
+        struct is_invocable_r_impl_tag {};
+
+        template < typename Void, typename R, typename F, typename... Args >
+        struct is_invocable_r_impl
+        : std::false_type {};
+
+        template < typename R, typename F, typename... Args >
+        struct is_invocable_r_impl<void_t<is_invocable_r_impl_tag, invoke_result_t<F, Args...>>, R, F, Args...>
+        : std::conditional<
+            std::is_void<R>::value,
+            std::true_type,
+            std::is_convertible<invoke_result_t<F, Args...>, R>>::type {};
+    }
+
+    template < typename R, typename F, typename... Args >
+    struct is_invocable_r
+    : impl::is_invocable_r_impl<void, R, F, Args...> {};
+
+    template < typename F, typename... Args >
+    using is_invocable = is_invocable_r<void, F, Args...>;
+}
+
+//
+// apply
+//
+
+namespace invoke_hpp
+{
+    namespace impl
+    {
+        template < typename F, typename Tuple, std::size_t... I >
+        constexpr auto apply_impl(F&& f, Tuple&& args, index_sequence<I...>)
+        INVOKE_HPP_NOEXCEPT_DECLTYPE_RETURN(
+            invoke_hpp::invoke(
+                std::forward<F>(f),
+                std::get<I>(std::forward<Tuple>(args))...))
+    }
+
+    template < typename F, typename Tuple >
+    constexpr auto apply(F&& f, Tuple&& args)
+    INVOKE_HPP_NOEXCEPT_DECLTYPE_RETURN(
+        impl::apply_impl(
+            std::forward<F>(f),
+            std::forward<Tuple>(args),
+            make_index_sequence<std::tuple_size<typename std::decay<Tuple>::type>::value>()))
+}
+
+#undef INVOKE_HPP_NOEXCEPT_DECLTYPE_RETURN

--- a/mlir/lib/Conversion/RiseToImperative/ConvertRiseToImperative.cpp
+++ b/mlir/lib/Conversion/RiseToImperative/ConvertRiseToImperative.cpp
@@ -255,6 +255,8 @@ void RiseToImperativePattern::rewrite(FuncOp funcOp,
       Block::iterator(loweringUnit.region().front().end()));
   rewriter.eraseOp(loweringUnit);
 
+  funcOp.dump();
+
   return;
 }
 
@@ -1201,11 +1203,9 @@ Value resolveIndexing(Value val, SmallVector<OutputPathType, 10> path,
                  dyn_cast<TransposeAccIntermediateOp>(val.getDefiningOp())) {
     // TODO: do we want this? Does it even make sense?
     emitRemark(val.getLoc()) << "resolveIndexing for TransposeAcc (!)";
-    std::cout << "moin!\n" << std::flush;
     printPath(path);
     auto n = path.pop_back_val();
     auto m = path.pop_back_val();
-    std::cout << "moin1!\n" << std::flush;
 
     path.push_back(n);
     path.push_back(m);

--- a/mlir/lib/Conversion/RiseToImperative/ConvertRiseToImperative.cpp
+++ b/mlir/lib/Conversion/RiseToImperative/ConvertRiseToImperative.cpp
@@ -882,7 +882,6 @@ mlir::Value lowerPad(NatAttr n, NatAttr l, NatAttr r, DataTypeAttr t, Type type,
 void lowerAssign(AssignOp assignOp, PatternRewriter &rewriter) {
   Location loc = assignOp.getLoc();
   emitRemark(loc) << "Lowering Assignment";
-  // TODO: set insertPOint somewhere
   if (assignOp.value().isa<OpResult>()) {
     rewriter.setInsertionPoint(assignOp);
   } else {
@@ -1139,28 +1138,6 @@ Value resolveIndexing(Value val, SmallVector<OutputPathType, 10> path,
     path.push_back(newIndex);
 
     return resolveIndexing(splitIntermediateOp.value(), path, rewriter);
-  } else if (SplitAccIntermediateOp splitAccIntermediateOp =
-                 dyn_cast<SplitAccIntermediateOp>(val.getDefiningOp())) {
-    // TODO: do we want this? Does it even make sense?
-    emitRemark(val.getLoc()) << "resolveIndexing for SplitAcc (!)";
-
-    auto i = mpark::get<Value>(path.pop_back_val());
-    auto j = mpark::get<Value>(path.pop_back_val());
-
-    auto cstN =
-        rewriter
-            .create<ConstantIndexOp>(splitAccIntermediateOp.getLoc(),
-                                     splitAccIntermediateOp.n().getIntValue())
-            .getResult();
-    auto i_times_n =
-        rewriter.create<MulIOp>(splitAccIntermediateOp.getLoc(), i, cstN)
-            .getResult();
-    auto newIndex =
-        rewriter.create<AddIOp>(splitAccIntermediateOp.getLoc(), i_times_n, j)
-            .getResult();
-    path.push_back(newIndex);
-
-    return resolveIndexing(splitAccIntermediateOp.value(), path, rewriter);
   } else if (JoinIntermediateOp joinIntermediateOp =
                  dyn_cast<JoinIntermediateOp>(val.getDefiningOp())) {
     emitRemark(val.getLoc()) << "resolveIndexing for Join";

--- a/mlir/lib/Conversion/RiseToImperative/ConvertRiseToImperative.cpp
+++ b/mlir/lib/Conversion/RiseToImperative/ConvertRiseToImperative.cpp
@@ -58,6 +58,8 @@ void lowerAndStoreSplit(NatAttr n, NatAttr m, DataTypeAttr t, Value array,
                         Value out, Location loc, PatternRewriter &rewriter);
 void lowerAndStoreJoin(NatAttr n, NatAttr m, DataTypeAttr t, Value array,
                        Value out, Location loc, PatternRewriter &rewriter);
+void lowerAndStoreTranspose(NatAttr n, NatAttr m, DataTypeAttr t, Value array,
+                            Value out, Location loc, PatternRewriter &rewriter);
 
 mlir::Value lowerLiteral(Value literalValue, Location loc,
                          PatternRewriter &rewriter);
@@ -243,12 +245,14 @@ void RiseToImperativePattern::rewrite(FuncOp funcOp,
     rewriter.eraseOp(op);
   }
 
+
   // inline all operations of the loweringUnit and erase it
   rewriter.setInsertionPointAfter(loweringUnit);
   rewriter.getInsertionBlock()->getOperations().splice(
       rewriter.getInsertionPoint(),
       loweringUnit.getRegion().front().getOperations(),
-      loweringUnit.getRegion().front().begin(), Block::iterator(loweringUnit.region().front().end()));
+      loweringUnit.getRegion().front().begin(),
+      Block::iterator(loweringUnit.region().front().end()));
   rewriter.eraseOp(loweringUnit);
 
   return;
@@ -319,9 +323,15 @@ void lowerAndStore(Value expr, Value out, PatternRewriter &rewriter) {
                          apply.getOperand(1), out, splitOp.getLoc(), rewriter);
       return;
     } else if (JoinOp joinOp = dyn_cast<JoinOp>(appliedFun)) {
-      emitRemark(joinOp.getLoc()) << "AccT of Join";
+      emitRemark(joinOp.getLoc()) << "lowerAndStore of Join";
       lowerAndStoreJoin(joinOp.nAttr(), joinOp.mAttr(), joinOp.tAttr(),
                         apply.getOperand(1), out, joinOp.getLoc(), rewriter);
+      return;
+    } else if (TransposeOp transposeOp = dyn_cast<TransposeOp>(appliedFun)) {
+      emitRemark(transposeOp.getLoc()) << "lowerAndStore of Transpose";
+      lowerAndStoreTranspose(transposeOp.nAttr(), transposeOp.mAttr(),
+                             transposeOp.tAttr(), apply.getOperand(1), out,
+                             transposeOp.getLoc(), rewriter);
       return;
     } else if (LambdaOp lambdaOp = dyn_cast<LambdaOp>(appliedFun)) {
       emitRemark(appliedFun->getLoc()) << "lowerAndStore of Lambda";
@@ -479,6 +489,7 @@ mlir::Value lower(mlir::Value expr, Block::iterator contLocation,
       << " leaving Value as is.";
 
   rewriter.restoreInsertionPoint(oldInsertPoint);
+
   return expr;
 }
 
@@ -502,7 +513,7 @@ void lowerAndStoreReduceSeq(NatAttr n, DataTypeAttr s, DataTypeAttr t,
 
   // Introduce a temporary to accumulate into, or accumulate direcly in the
   // output
-  bool defineNewAccumulator = false;
+  bool defineNewAccumulator = true;
 
   Value accum;
   if (defineNewAccumulator) {
@@ -515,11 +526,8 @@ void lowerAndStoreReduceSeq(NatAttr n, DataTypeAttr s, DataTypeAttr t,
     rewriter.setInsertionPointToStart(&embedOp.region().front());
 
     AllocOp alloc = rewriter.create<AllocOp>(
-        loc, MemRefType::get(ArrayRef<int64_t>{0},
+        loc, MemRefType::get(ArrayRef<int64_t>{},
                              FloatType::getF32(rewriter.getContext())));
-
-    rewriter.create<linalg::FillOp>(initializer.getLoc(), alloc.getResult(),
-                                    contInit);
     rewriter.create<rise::ReturnOp>(initializer.getLoc(), alloc.getResult());
 
     rewriter.setInsertionPointAfter(embedOp);
@@ -605,7 +613,6 @@ void lowerAndStoreMapSeq(NatAttr n, DataTypeAttr s, DataTypeAttr t, Value f,
     loopInductionVar = forLoop.getInductionVar();
     forLoopBody = forLoop.getBody();
   }
-
   rewriter.setInsertionPointToStart(forLoopBody);
 
   LambdaOp fLambda = dyn_cast<LambdaOp>(f.getDefiningOp());
@@ -622,7 +629,6 @@ void lowerAndStoreMapSeq(NatAttr n, DataTypeAttr s, DataTypeAttr t, Value f,
   LambdaOp lambdaCopy = cast<LambdaOp>(rewriter.clone(*fLambda));
   auto fxi = rewriter.create<ApplyOp>(loc, lambdaCopy.getType(),
                                       lambdaCopy.getResult(), xi.getResult());
-
   auto outi = rewriter.create<IdxOp>(
       loc, out.getType().dyn_cast<ArrayType>().getElementType(), out,
       loopInductionVar);
@@ -678,6 +684,16 @@ void lowerAndStoreJoin(NatAttr n, NatAttr m, DataTypeAttr t, Value array,
   lowerAndStore(array, joinAccInterm.getResult(), rewriter);
 }
 
+void lowerAndStoreTranspose(NatAttr n, NatAttr m, DataTypeAttr t, Value array,
+                            Value out, Location loc,
+                            PatternRewriter &rewriter) {
+  ArrayType transposeAccType = ArrayType::get(
+      rewriter.getContext(), n.getValue(),
+      ArrayType::get(rewriter.getContext(), m.getValue(), t.getValue()));
+  auto transposeAccInterm = rewriter.create<TransposeAccIntermediateOp>(
+      loc, transposeAccType, out, n, m, t);
+  lowerAndStore(array, transposeAccInterm.getResult(), rewriter);
+}
 //===----------------------------------------------------------------------===//
 // Lower{Operation}
 //===----------------------------------------------------------------------===//
@@ -865,10 +881,10 @@ mlir::Value lowerPad(NatAttr n, NatAttr l, NatAttr r, DataTypeAttr t, Type type,
 
 void lowerAssign(AssignOp assignOp, PatternRewriter &rewriter) {
   Location loc = assignOp.getLoc();
-  emitRemark(loc) << "Codegen for Assign";
-
+  emitRemark(loc) << "Lowering Assignment";
+  // TODO: set insertPOint somewhere
   if (assignOp.value().isa<OpResult>()) {
-    rewriter.setInsertionPoint(assignOp.assignee().getDefiningOp());
+    rewriter.setInsertionPoint(assignOp);
   } else {
     rewriter.setInsertionPointToStart(
         &assignOp.value().getParentRegion()->front());
@@ -887,23 +903,22 @@ resolveStoreIndexing(Value storeLocation, Value val,
                      SmallVector<OutputPathType, 10> path,
                      PatternRewriter &rewriter) {
   if (!storeLocation.isa<OpResult>()) {
-    emitRemark(val.getLoc()) << "CodegenStore for BlockArg";
+    emitRemark(val.getLoc()) << "resolveStoreIndexing for BlockArg";
     generateReadAccess(path, val, storeLocation, rewriter);
     return path;
   }
 
   if (IdxOp idx = dyn_cast<IdxOp>(storeLocation.getDefiningOp())) {
-    emitRemark(val.getLoc()) << "CodegenStore for idx";
+    emitRemark(val.getLoc()) << "resolveStoreIndexing for idx";
 
     path.push_back(idx.iv());
-
     return resolveStoreIndexing(idx.array(), val, path, rewriter);
   } else if (CastOp castOp = dyn_cast<CastOp>(storeLocation.getDefiningOp())) {
-    emitRemark(val.getLoc()) << "CodegenStore for cast";
+    emitRemark(val.getLoc()) << "resolveStoreIndexing for cast";
     return resolveStoreIndexing(castOp.getOperand(), val, path, rewriter);
   } else if (JoinAccIntermediateOp joinAccOp = dyn_cast<JoinAccIntermediateOp>(
                  storeLocation.getDefiningOp())) {
-    emitRemark(val.getLoc()) << "CodegenStore for joinAcc";
+    emitRemark(val.getLoc()) << "resolveStoreIndexing for joinAcc";
     auto i = mpark::get<Value>(path.pop_back_val());
     auto j = mpark::get<Value>(path.pop_back_val());
 
@@ -921,7 +936,7 @@ resolveStoreIndexing(Value storeLocation, Value val,
   } else if (SplitAccIntermediateOp splitAccOp =
                  dyn_cast<SplitAccIntermediateOp>(
                      storeLocation.getDefiningOp())) {
-    emitRemark(val.getLoc()) << "CodegenStore for splitAcc";
+    emitRemark(val.getLoc()) << "resolveStoreIndexing for splitAcc";
     auto loc = splitAccOp.getLoc();
     auto lhs = mpark::get<Value>(path.pop_back_val());
     auto rhs =
@@ -941,14 +956,34 @@ resolveStoreIndexing(Value storeLocation, Value val,
     path.push_back(result);
     path.push_back(divResult);
     return resolveStoreIndexing(splitAccOp.getOperand(), val, path, rewriter);
+  } else if (TransposeAccIntermediateOp transposeAccIntermediateOp =
+                 dyn_cast<TransposeAccIntermediateOp>(
+                     storeLocation.getDefiningOp())) {
+    emitRemark(val.getLoc()) << "resolveStoreIndexing for transposeAcc";
+    auto i = mpark::get<Value>(path.pop_back_val());
+    auto j = mpark::get<Value>(path.pop_back_val());
+    path.push_back(i);
+    path.push_back(j);
+
+    return resolveStoreIndexing(transposeAccIntermediateOp.getOperand(), val,
+                                path, rewriter);
   } else if (EmbedOp embedOp =
                  dyn_cast<EmbedOp>(storeLocation.getDefiningOp())) {
-    emitRemark(val.getLoc()) << "CodegenStore for embed";
+    emitRemark(val.getLoc()) << "resolveStoreIndexing for embed";
     assert(embedOp.getNumOperands() == 0 &&
            "codegenstore for embed with operands not handled yet.");
 
     auto oldInsertPoint = rewriter.saveInsertionPoint();
     rewriter.setInsertionPointAfter(embedOp);
+
+    // replace blockArgs in the region with results of the codegen for the
+    // operands
+    for (int i = 0; i < embedOp.getOperands().size(); i++) {
+      embedOp.region().front().getArgument(i).replaceUsesWithIf(
+          embedOp.getOperand(i), [&](OpOperand &operand) {
+            return embedOp.getOperation()->isAncestor(operand.getOwner());
+          });
+    }
 
     // replace uses of embed value with returned value
     rise::ReturnOp embedReturn = dyn_cast<rise::ReturnOp>(
@@ -968,9 +1003,10 @@ resolveStoreIndexing(Value storeLocation, Value val,
     return path;
   }
 
-  emitRemark(val.getLoc())
-      << "CodegenStore for "
-      << val.getDefiningOp()->getName().getStringRef().str();
+  emitRemark(storeLocation.getLoc())
+      << "resolveStoreIndexing for "
+      << storeLocation.getDefiningOp()->getName().getStringRef().str()
+      << " generating read access.";
 
   generateReadAccess(path, val, storeLocation, rewriter);
   return path;
@@ -980,11 +1016,12 @@ Value resolveIndexing(Value val, SmallVector<OutputPathType, 10> path,
                       PatternRewriter &rewriter) {
 
   if (!val.isa<OpResult>()) {
-    emitRemark(val.getLoc()) << "reached a blockArg in Codegen, reversing";
+    emitRemark(val.getLoc())
+        << "reached a blockArg in resolveIndexing, reversing";
     return generateWriteAccess(path, val, rewriter);
   }
   if (EmbedOp embedOp = dyn_cast<EmbedOp>(val.getDefiningOp())) {
-    emitRemark(embedOp.getLoc()) << "Codegen for Embed";
+    emitRemark(embedOp.getLoc()) << "resolveIndexing for Embed";
 
     auto oldInsertPoint = rewriter.saveInsertionPoint();
 
@@ -999,8 +1036,10 @@ Value resolveIndexing(Value val, SmallVector<OutputPathType, 10> path,
     // replace blockArgs in the region with results of the codegen for the
     // operands
     for (int i = 0; i < embedOp.getOperands().size(); i++) {
-      embedOp.region().front().getArgument(i).replaceAllUsesWith(
-          embedOp.getOperand(i));
+      embedOp.region().front().getArgument(i).replaceUsesWithIf(
+          embedOp.getOperand(i), [&](OpOperand &operand) {
+            return embedOp.getOperation()->isAncestor(operand.getOwner());
+          });
     }
     // replace uses of embed value with returned value
     rise::ReturnOp embedReturn = dyn_cast<rise::ReturnOp>(
@@ -1020,23 +1059,20 @@ Value resolveIndexing(Value val, SmallVector<OutputPathType, 10> path,
     return embedReturn.getOperand(0);
 
   } else if (IdxOp idx = dyn_cast<IdxOp>(val.getDefiningOp())) {
-    // printPath(path, "idx");
-
-    emitRemark(idx.getLoc()) << "Codegen for idx";
+    emitRemark(idx.getLoc()) << "resolveIndexing for idx";
 
     Value iv = idx.iv();
     path.push_back(iv);
     return resolveIndexing(idx.array(), path, rewriter);
   } else if (AllocOp alloc = dyn_cast<AllocOp>(val.getDefiningOp())) {
-    emitRemark(alloc.getLoc()) << "Codegen for alloc";
+    emitRemark(alloc.getLoc()) << "resolveIndexing for alloc";
 
     // call to reverse here.
     return generateWriteAccess(path, alloc.getResult(), rewriter);
   } else if (MapReadIntermediateOp mapReadOp =
                  dyn_cast<MapReadIntermediateOp>(val.getDefiningOp())) {
-    // printPath(path, "MapRead:");
 
-    emitRemark(mapReadOp.getLoc()) << "Codegen for MapRead";
+    emitRemark(mapReadOp.getLoc()) << "resolveIndexing for MapRead";
 
     auto i = mpark::get<Value>(path.pop_back_val());
     auto idx = rewriter.create<IdxOp>(
@@ -1048,7 +1084,7 @@ Value resolveIndexing(Value val, SmallVector<OutputPathType, 10> path,
     return resolveIndexing(mapReadOp.f(), path, rewriter);
   } else if (ZipIntermediateOp zipIntermOp =
                  dyn_cast<ZipIntermediateOp>(val.getDefiningOp())) {
-    emitRemark(zipIntermOp.getLoc()) << "Codegen for zip";
+    emitRemark(zipIntermOp.getLoc()) << "resolveIndexing for zip";
     OutputPathType sndLastElem = path[path.size() - 2];
     int *fst = mpark::get_if<int>(&sndLastElem);
 
@@ -1065,7 +1101,7 @@ Value resolveIndexing(Value val, SmallVector<OutputPathType, 10> path,
   } else if (FstIntermediateOp fstIntermOp =
                  dyn_cast<FstIntermediateOp>(val.getDefiningOp())) {
     // printPath(path, "fst");
-    emitRemark(fstIntermOp.getLoc()) << "Codegen for fst";
+    emitRemark(fstIntermOp.getLoc()) << "resolveIndexing for fst";
 
     path.push_back(true);
     return resolveIndexing(fstIntermOp.value(), path, rewriter);
@@ -1073,18 +1109,18 @@ Value resolveIndexing(Value val, SmallVector<OutputPathType, 10> path,
   } else if (SndIntermediateOp sndIntermOp =
                  dyn_cast<SndIntermediateOp>(val.getDefiningOp())) {
     // printPath(path, "snd");
-    emitRemark(sndIntermOp.getLoc()) << "Codegen for snd";
+    emitRemark(sndIntermOp.getLoc()) << "resolveIndexing for snd";
 
     path.push_back(false);
     return resolveIndexing(sndIntermOp.value(), path, rewriter);
 
   } else if (isa<LoadOp>(val.getDefiningOp()) ||
              isa<AffineLoadOp>(val.getDefiningOp())) {
-    emitRemark(val.getLoc()) << "Codegen for Load";
+    emitRemark(val.getLoc()) << "resolveIndexing for Load";
     return val;
   } else if (SplitIntermediateOp splitIntermediateOp =
                  dyn_cast<SplitIntermediateOp>(val.getDefiningOp())) {
-    emitRemark(val.getLoc()) << "Codegen for Split";
+    emitRemark(val.getLoc()) << "resolveIndexing for Split";
 
     auto i = mpark::get<Value>(path.pop_back_val());
     auto j = mpark::get<Value>(path.pop_back_val());
@@ -1103,9 +1139,31 @@ Value resolveIndexing(Value val, SmallVector<OutputPathType, 10> path,
     path.push_back(newIndex);
 
     return resolveIndexing(splitIntermediateOp.value(), path, rewriter);
+  } else if (SplitAccIntermediateOp splitAccIntermediateOp =
+                 dyn_cast<SplitAccIntermediateOp>(val.getDefiningOp())) {
+    // TODO: do we want this? Does it even make sense?
+    emitRemark(val.getLoc()) << "resolveIndexing for SplitAcc (!)";
+
+    auto i = mpark::get<Value>(path.pop_back_val());
+    auto j = mpark::get<Value>(path.pop_back_val());
+
+    auto cstN =
+        rewriter
+            .create<ConstantIndexOp>(splitAccIntermediateOp.getLoc(),
+                                     splitAccIntermediateOp.n().getIntValue())
+            .getResult();
+    auto i_times_n =
+        rewriter.create<MulIOp>(splitAccIntermediateOp.getLoc(), i, cstN)
+            .getResult();
+    auto newIndex =
+        rewriter.create<AddIOp>(splitAccIntermediateOp.getLoc(), i_times_n, j)
+            .getResult();
+    path.push_back(newIndex);
+
+    return resolveIndexing(splitAccIntermediateOp.value(), path, rewriter);
   } else if (JoinIntermediateOp joinIntermediateOp =
                  dyn_cast<JoinIntermediateOp>(val.getDefiningOp())) {
-    emitRemark(val.getLoc()) << "Codegen for Join";
+    emitRemark(val.getLoc()) << "resolveIndexing for Join";
 
     auto loc = joinIntermediateOp.getLoc();
     auto lhs = mpark::get<Value>(path.pop_back_val());
@@ -1130,8 +1188,7 @@ Value resolveIndexing(Value val, SmallVector<OutputPathType, 10> path,
     return resolveIndexing(joinIntermediateOp.value(), path, rewriter);
   } else if (TransposeIntermediateOp transposeIntermediateOp =
                  dyn_cast<TransposeIntermediateOp>(val.getDefiningOp())) {
-    // printPath(path, "Transpose:");
-    emitRemark(val.getLoc()) << "Codegen for Transpose";
+    emitRemark(val.getLoc()) << "resolveIndexing for Transpose";
     auto n = path.pop_back_val();
     auto m = path.pop_back_val();
 
@@ -1140,18 +1197,31 @@ Value resolveIndexing(Value val, SmallVector<OutputPathType, 10> path,
 
     return resolveIndexing(transposeIntermediateOp.getOperand(), path,
                            rewriter);
+  } else if (TransposeAccIntermediateOp transposeAccIntermediateOp =
+                 dyn_cast<TransposeAccIntermediateOp>(val.getDefiningOp())) {
+    // TODO: do we want this? Does it even make sense?
+    emitRemark(val.getLoc()) << "resolveIndexing for TransposeAcc (!)";
+    std::cout << "moin!\n" << std::flush;
+    printPath(path);
+    auto n = path.pop_back_val();
+    auto m = path.pop_back_val();
+    std::cout << "moin1!\n" << std::flush;
+
+    path.push_back(n);
+    path.push_back(m);
+
+    return resolveIndexing(transposeAccIntermediateOp.getOperand(), path,
+                           rewriter);
   } else if (SlideIntermediateOp slideIntermediateOp =
                  dyn_cast<SlideIntermediateOp>(val.getDefiningOp())) {
-    // printPath(path, "Slide:");
-
-    emitRemark(val.getLoc()) << "Codegen for Slide";
+    emitRemark(val.getLoc()) << "resolveIndexing for Slide";
 
     Value i = mpark::get<Value>(path.pop_back_val());
     Value j = mpark::get<Value>(path.pop_back_val());
 
     if (!j) {
       emitError(slideIntermediateOp.getLoc())
-          << "Cannot do codegen for slide, path structure not correct!";
+          << "Cannot do resolveIndexing for slide, path structure not correct!";
     }
 
     Value s2 =
@@ -1172,7 +1242,7 @@ Value resolveIndexing(Value val, SmallVector<OutputPathType, 10> path,
     return resolveIndexing(slideIntermediateOp.value(), path, rewriter);
   } else if (PadIntermediateOp padIntermediateOp =
                  dyn_cast<PadIntermediateOp>(val.getDefiningOp())) {
-    emitRemark(val.getLoc()) << "Codegen for Pad";
+    emitRemark(val.getLoc()) << "resolveIndexing for Pad";
     Location loc = padIntermediateOp.getLoc();
 
     Value i = mpark::get<Value>(path.pop_back_val());
@@ -1218,19 +1288,19 @@ Value resolveIndexing(Value val, SmallVector<OutputPathType, 10> path,
     return resolveIndexing(padIntermediateOp.array(), path, rewriter);
   } else if (InOp inOp = dyn_cast<InOp>(val.getDefiningOp())) {
     emitRemark(val.getLoc())
-        << "Codegen for In, generating read operation for operand";
+        << "resolveIndexing for In, generating read operation for operand";
     return generateWriteAccess(path, inOp.input(), rewriter);
   } else if (CastOp castOp = dyn_cast<CastOp>(val.getDefiningOp())) {
-    emitRemark(val.getLoc()) << "Codegen for Cast, reversing";
+    emitRemark(val.getLoc()) << "resolveIndexing for Cast, reversing";
     return generateWriteAccess(path, castOp.getOperand(), rewriter);
   }
 
   emitRemark(val.getLoc())
-      << "I don't know how to do codegen for: "
+      << "I don't know how to do resolveIndexing for: "
       << val.getDefiningOp()->getName().getStringRef().str()
       << " this is prob. an operation from another dialect. We walk "
          "recursively through the operands until we hit something we can "
-         "do codegen for.";
+         "do resolveIndexing for.";
 
   int i = 0;
   for (auto operand : (val.getDefiningOp()->getOperands())) {
@@ -1269,10 +1339,7 @@ void generateReadAccess(SmallVector<OutputPathType, 10> path, Value storeVal,
     assert(val && "path is ill structured!");
     indexValues.push_back(*val);
   }
-  int rank = storeLoc.getType().dyn_cast<MemRefType>().getRank();
-  if (indexValues.size() != rank) {
-    indexValues.erase(indexValues.begin());
-  }
+
   if (isa<AffineForOp>(rewriter.getBlock()->getParent()->getParentOp())) {
     rewriter.create<AffineStoreOp>(storeLoc.getLoc(), storeVal, storeLoc,
                                    llvm::makeArrayRef(indexValues));
@@ -1363,7 +1430,7 @@ void ConvertRiseToImperativePass::runOnFunction() {
   target.addLegalDialect<scf::SCFDialect>();
   target.addLegalDialect<AffineDialect>();
   target.addLegalDialect<linalg::LinalgDialect>();
-//  target.addLegalDialect<rise::RiseDialect>(); // for debugging purposes
+  //  target.addLegalDialect<rise::RiseDialect>(); // for debugging purposes
 
   target.addDynamicallyLegalOp<FuncOp>([](FuncOp funcOp) {
     bool riseInside = false;
@@ -1379,7 +1446,7 @@ void ConvertRiseToImperativePass::runOnFunction() {
 
   bool erased;
   applyOpPatternsAndFold(module, patterns, &erased);
-//  applyFullConversion(module, target, patterns);
+  //  applyFullConversion(module, target, patterns);
   return;
 }
 

--- a/mlir/lib/Conversion/RiseToImperative/ConvertRiseToImperative.cpp
+++ b/mlir/lib/Conversion/RiseToImperative/ConvertRiseToImperative.cpp
@@ -1139,28 +1139,6 @@ Value resolveIndexing(Value val, SmallVector<OutputPathType, 10> path,
     path.push_back(newIndex);
 
     return resolveIndexing(splitIntermediateOp.value(), path, rewriter);
-  } else if (SplitAccIntermediateOp splitAccIntermediateOp =
-                 dyn_cast<SplitAccIntermediateOp>(val.getDefiningOp())) {
-    // TODO: do we want this? Does it even make sense?
-    emitRemark(val.getLoc()) << "resolveIndexing for SplitAcc (!)";
-
-    auto i = mpark::get<Value>(path.pop_back_val());
-    auto j = mpark::get<Value>(path.pop_back_val());
-
-    auto cstN =
-        rewriter
-            .create<ConstantIndexOp>(splitAccIntermediateOp.getLoc(),
-                                     splitAccIntermediateOp.n().getIntValue())
-            .getResult();
-    auto i_times_n =
-        rewriter.create<MulIOp>(splitAccIntermediateOp.getLoc(), i, cstN)
-            .getResult();
-    auto newIndex =
-        rewriter.create<AddIOp>(splitAccIntermediateOp.getLoc(), i_times_n, j)
-            .getResult();
-    path.push_back(newIndex);
-
-    return resolveIndexing(splitAccIntermediateOp.value(), path, rewriter);
   } else if (JoinIntermediateOp joinIntermediateOp =
                  dyn_cast<JoinIntermediateOp>(val.getDefiningOp())) {
     emitRemark(val.getLoc()) << "resolveIndexing for Join";
@@ -1196,21 +1174,6 @@ Value resolveIndexing(Value val, SmallVector<OutputPathType, 10> path,
     path.push_back(m);
 
     return resolveIndexing(transposeIntermediateOp.getOperand(), path,
-                           rewriter);
-  } else if (TransposeAccIntermediateOp transposeAccIntermediateOp =
-                 dyn_cast<TransposeAccIntermediateOp>(val.getDefiningOp())) {
-    // TODO: do we want this? Does it even make sense?
-    emitRemark(val.getLoc()) << "resolveIndexing for TransposeAcc (!)";
-    std::cout << "moin!\n" << std::flush;
-    printPath(path);
-    auto n = path.pop_back_val();
-    auto m = path.pop_back_val();
-    std::cout << "moin1!\n" << std::flush;
-
-    path.push_back(n);
-    path.push_back(m);
-
-    return resolveIndexing(transposeAccIntermediateOp.getOperand(), path,
                            rewriter);
   } else if (SlideIntermediateOp slideIntermediateOp =
                  dyn_cast<SlideIntermediateOp>(val.getDefiningOp())) {

--- a/mlir/lib/Dialect/Rise/EDSC/Builders.cpp
+++ b/mlir/lib/Dialect/Rise/EDSC/Builders.cpp
@@ -133,6 +133,15 @@ void mlir::edsc::op::rise_return(Value returnValue) {
   return;
 }
 
+void mlir::edsc::op::lowering_unit(function_ref<void()> bodyBuilder) {
+  OperationBuilder<LoweringUnitOp>(
+      [&](OpBuilder &nestedBuilder, Location nestedLoc) {
+        ScopedContext nestedContext(nestedBuilder, nestedLoc);
+        OpBuilder::InsertionGuard guard(nestedBuilder);
+        bodyBuilder();
+      });
+}
+
 //===----------------------------------------------------------------------===//
 // Rise Operations: Patterns
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/Rise/EDSC/HighLevel.cpp
+++ b/mlir/lib/Dialect/Rise/EDSC/HighLevel.cpp
@@ -132,11 +132,15 @@ Value mlir::edsc::highlevel::conv2D(Value input, Value kernel, int padl, int pad
   int steptb = 1;
 
   ScalarType elementType = scalarF32Type();
-  Value padded = pad2D(natType(padt), natType(padb),
-                       natType(padl), natType(padr), input);
+
+  Value adjustedInput = input;
+  if (padl != 0 || padr != 0 || padt != 0 || padb != 0) {
+    adjustedInput = pad2D(natType(padt), natType(padb),
+                         natType(padl), natType(padr), input);
+  }
 
   Value slided = slide2D(kernelHeight.getSize(), natType(1),
-                         kernelWidth.getSize(), natType(1), padded);
+                         kernelWidth.getSize(), natType(1), adjustedInput);
   return mapSeq2D(
       elementType,
       [&](Value slidingWindow) {

--- a/mlir/lib/Dialect/Rise/EDSC/HighLevel.cpp
+++ b/mlir/lib/Dialect/Rise/EDSC/HighLevel.cpp
@@ -45,8 +45,8 @@ Value mlir::edsc::highlevel::matrix_multiplication(int M, int N, int K, Value A,
       arowType.getElementType().dyn_cast<rise::ScalarType>();
 
   // clang-format off
-  return mapSeq(arowType, [&](Value arow) {
-    return (mapSeq(bcolType,  [&](Value bcol) {
+  return mapSeq(BType.getElementType(), [&](Value arow) {
+    return (mapSeq(scalarF32Type(),  [&](Value bcol) {
       return (reduceSeq(elementType, [&](Value tuple, Value acc){
         return (embed3(elementType, ValueRange{fst(elementType, elementType, tuple),
                                                snd(elementType, elementType, tuple), acc},
@@ -197,7 +197,6 @@ Value mlir::edsc::highlevel::conv2DSeparated(Value input, Value kernelH,
         Value mapped = mapSeq(
             elementType,
             [&](Value nbh) {
-              nbh.getType().dump();
               Value zipped = zip(nbh, kernelH);
               Value reduced = reduceSeq(
                   elementType,
@@ -286,12 +285,9 @@ Value mlir::edsc::highlevel::conv2DTF(Value input, Value kernel) {
                          [&](Value slidingWindow) {
                            Value zipped = zip2D(slidingWindow, reshapedKernel);
                            Value joined = join(zipped);
-
                            return reduceSeq(
                                elementType,
                                [&](Value tuple, Value acc) {
-                                 tuple.getType().dump();
-                                 acc.getType().dump();
                                  return embed3(
                                      scalarF32Type(),
                                      {fst(tuple), snd(tuple), acc},

--- a/mlir/lib/Dialect/Rise/EDSC/HighLevel.cpp
+++ b/mlir/lib/Dialect/Rise/EDSC/HighLevel.cpp
@@ -119,9 +119,21 @@ Value mlir::edsc::highlevel::conv2D(Value input, Value kernel) {
   int padOuterl = ceil((inputHeight.getSize().getIntValue() - nHeight) / 2.0);
   int padOuterr = floor((inputHeight.getSize().getIntValue() - nHeight) / 2.0);
 
+  return conv2D(input, kernel, padInnerl, padInnerr, padOuterl, padOuterr);
+}
+
+Value mlir::edsc::highlevel::conv2D(Value input, Value kernel, int padl, int padr, int padt, int padb) {
+  ArrayType inputHeight = input.getType().dyn_cast<ArrayType>();
+  ArrayType inputWidth = inputHeight.getElementType().dyn_cast<ArrayType>();
+  ArrayType kernelHeight = kernel.getType().dyn_cast<ArrayType>();
+  ArrayType kernelWidth = kernelHeight.getElementType().dyn_cast<ArrayType>();
+
+  int steplr = 1;
+  int steptb = 1;
+
   ScalarType elementType = scalarF32Type();
-  Value padded = pad2D(natType(padOuterl), natType(padOuterr),
-                       natType(padInnerl), natType(padInnerr), input);
+  Value padded = pad2D(natType(padt), natType(padb),
+                       natType(padl), natType(padr), input);
 
   Value slided = slide2D(kernelHeight.getSize(), natType(1),
                          kernelWidth.getSize(), natType(1), padded);
@@ -146,6 +158,7 @@ Value mlir::edsc::highlevel::conv2D(Value input, Value kernel) {
       },
       slided);
 }
+
 
 void mlir::edsc::highlevel::stencil2D(int M, int N, int outerWindowSize,
                                       int outerStep, int innerWindowSize,

--- a/mlir/lib/Dialect/Rise/IR/Ops.cpp
+++ b/mlir/lib/Dialect/Rise/IR/Ops.cpp
@@ -116,6 +116,17 @@ void EmbedOp::build(
 }
 
 //===----------------------------------------------------------------------===//
+// LoweringUnitOp
+//===----------------------------------------------------------------------===//
+LogicalResult parseLoweringUnitOp(OpAsmParser &parser, OperationState &result) {
+  Region *body = result.addRegion();
+  if (failed(parser.parseRegion(*body, {}, {}, false)))
+    return failure();
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // InOp
 //===----------------------------------------------------------------------===//
 LogicalResult parseInOp(OpAsmParser &parser, OperationState &result) {
@@ -598,12 +609,12 @@ LogicalResult parseReturnOp(OpAsmParser &parser, OperationState &result) {
   OpAsmParser::OperandType value;
   Type type;
 
-  // return value
-  if (failed(parser.parseOperand(value)) ||
-      failed(parser.parseColonType(type)) ||
-      failed(parser.resolveOperand(value, type, result.operands)))
-    failure();
-
+  if (parser.parseOptionalOperand(value).hasValue()) {
+    if (failed(parser.parseColonType(type)) ||
+        failed(parser.resolveOperand(value, type, result.operands)))
+      failure();
+    return success();
+  }
   return success();
 }
 

--- a/mlir/lib/Dialect/Rise/IR/Ops.cpp
+++ b/mlir/lib/Dialect/Rise/IR/Ops.cpp
@@ -125,6 +125,19 @@ LogicalResult parseLoweringUnitOp(OpAsmParser &parser, OperationState &result) {
 
   return success();
 }
+void LoweringUnitOp::build(
+    OpBuilder &builder, OperationState &result,
+    function_ref<void(OpBuilder &, Location)> bodyBuilder) {
+  Region *embedRegion = result.addRegion();
+  Block *body = new Block();
+  embedRegion->push_back(body);
+
+
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointToStart(body);
+    bodyBuilder(builder, result.location);
+  builder.create<rise::ReturnOp>(result.location, ValueRange{});
+}
 
 //===----------------------------------------------------------------------===//
 // InOp

--- a/mlir/test/Conversion/RiseToImperative/3D_map_add.mlir
+++ b/mlir/test/Conversion/RiseToImperative/3D_map_add.mlir
@@ -2,27 +2,30 @@
 
 func @print_memref_f32(memref<*xf32>)
 func @rise_fun(%outArg:memref<4x4x4xf32>, %inArg:memref<4x4x4xf32>) {
-    %array3D = rise.in %inArg : !rise.array<4, array<4, array<4, scalar<f32>>>>
-    %doubleFun = rise.lambda (%summand : !rise.scalar<f32>) -> !rise.scalar<f32> {
-        %result = rise.embed(%summand) {
-               %result = addf %summand, %summand : f32
-               rise.return %result : f32
-        } : !rise.scalar<f32>
-        rise.return %result : !rise.scalar<f32>
-    }
-    %map1 = rise.mapSeq #rise.nat<4> #rise.array<4, array<4, scalar<f32>>> #rise.array<4, array<4, scalar<f32>>>
-    %mapInnerLambda_1 = rise.lambda (%arraySlice_1 : !rise.array<4, array<4, scalar<f32>>>) -> !rise.array<4, array<4, scalar<f32>>> {
-        %map2 = rise.mapSeq #rise.nat<4> #rise.array<4, scalar<f32>> #rise.array<4, scalar<f32>>
-        %mapInnerLambda_2 = rise.lambda (%arraySlice_2 : !rise.array<4, scalar<f32>>) -> !rise.array<4, scalar<f32>> {
-            %map3 = rise.mapSeq #rise.nat<4> #rise.scalar<f32> #rise.scalar<f32>
-            %res = rise.apply %map3, %doubleFun, %arraySlice_2
-            rise.return %res : !rise.array<4, scalar<f32>>
+    rise.lowering_unit {
+        %array3D = rise.in %inArg : !rise.array<4, array<4, array<4, scalar<f32>>>>
+        %doubleFun = rise.lambda (%summand : !rise.scalar<f32>) -> !rise.scalar<f32> {
+            %result = rise.embed(%summand) {
+                   %result = addf %summand, %summand : f32
+                   rise.return %result : f32
+            } : !rise.scalar<f32>
+            rise.return %result : !rise.scalar<f32>
         }
-       %res = rise.apply %map2, %mapInnerLambda_2, %arraySlice_1
-       rise.return %res : !rise.array<4, array<4, scalar<f32>>>
+        %map1 = rise.mapSeq #rise.nat<4> #rise.array<4, array<4, scalar<f32>>> #rise.array<4, array<4, scalar<f32>>>
+        %mapInnerLambda_1 = rise.lambda (%arraySlice_1 : !rise.array<4, array<4, scalar<f32>>>) -> !rise.array<4, array<4, scalar<f32>>> {
+            %map2 = rise.mapSeq #rise.nat<4> #rise.array<4, scalar<f32>> #rise.array<4, scalar<f32>>
+            %mapInnerLambda_2 = rise.lambda (%arraySlice_2 : !rise.array<4, scalar<f32>>) -> !rise.array<4, scalar<f32>> {
+                %map3 = rise.mapSeq #rise.nat<4> #rise.scalar<f32> #rise.scalar<f32>
+                %res = rise.apply %map3, %doubleFun, %arraySlice_2
+                rise.return %res : !rise.array<4, scalar<f32>>
+            }
+           %res = rise.apply %map2, %mapInnerLambda_2, %arraySlice_1
+           rise.return %res : !rise.array<4, array<4, scalar<f32>>>
+        }
+        %res = rise.apply %map1, %mapInnerLambda_1, %array3D
+        rise.out %outArg <- %res
+        rise.return
     }
-    %res = rise.apply %map1, %mapInnerLambda_1, %array3D
-    rise.out %outArg <- %res
     return
 }
 func @mapMapId() {

--- a/mlir/test/Conversion/RiseToImperative/4D_map_add.mlir
+++ b/mlir/test/Conversion/RiseToImperative/4D_map_add.mlir
@@ -2,32 +2,35 @@
 
 func @print_memref_f32(memref<*xf32>)
 func @rise_fun(%outArg:memref<4x4x4x4xf32>, %inArg:memref<4x4x4x4xf32>) {
-    %array4D = rise.in %inArg : !rise.array<4, array<4, array<4, array<4, scalar<f32>>>>>
-    %doubleFun = rise.lambda (%summand : !rise.scalar<f32>) -> !rise.scalar<f32> {
-        %result = rise.embed(%summand) {
-               %result = addf %summand, %summand : f32
-               rise.return %result : f32
-        } : !rise.scalar<f32>
-        rise.return %result : !rise.scalar<f32>
-    }
-    %map1 = rise.mapSeq #rise.nat<4> #rise.array<4, array<4, array<4, scalar<f32>>>> #rise.array<4, array<4, array<4, scalar<f32>>>>
-    %mapInnerLambda_1 = rise.lambda (%arraySlice_1 : !rise.array<4, array<4, array<4, scalar<f32>>>>) -> !rise.array<4, array<4, array<4, scalar<f32>>>> {
-        %map2 = rise.mapSeq #rise.nat<4> #rise.array<4, array<4, scalar<f32>>> #rise.array<4, array<4, scalar<f32>>>
-        %mapInnerLambda_2 = rise.lambda (%arraySlice_2 : !rise.array<4, array<4, scalar<f32>>>) -> !rise.array<4, array<4, scalar<f32>>> {
-            %map3 = rise.mapSeq #rise.nat<4> #rise.array<4, scalar<f32>> #rise.array<4, scalar<f32>>
-                %mapInnerLambda_3 = rise.lambda (%arraySlice_3 : !rise.array<4, scalar<f32>>) -> !rise.array<4, scalar<f32>> {
-                    %map4 = rise.mapSeq #rise.nat<4> #rise.scalar<f32> #rise.scalar<f32>
-                    %res = rise.apply %map4, %doubleFun, %arraySlice_3
-                    rise.return %res : !rise.array<4, scalar<f32>>
-                }
-            %res = rise.apply %map3, %mapInnerLambda_3, %arraySlice_2
-            rise.return %res : !rise.array<4, array<4, scalar<f32>>>
+    rise.lowering_unit {
+        %array4D = rise.in %inArg : !rise.array<4, array<4, array<4, array<4, scalar<f32>>>>>
+        %doubleFun = rise.lambda (%summand : !rise.scalar<f32>) -> !rise.scalar<f32> {
+            %result = rise.embed(%summand) {
+                   %result = addf %summand, %summand : f32
+                   rise.return %result : f32
+            } : !rise.scalar<f32>
+            rise.return %result : !rise.scalar<f32>
         }
-       %res = rise.apply %map2, %mapInnerLambda_2, %arraySlice_1
-       rise.return %res : !rise.array<4, array<4, array<4, scalar<f32>>>>
+        %map1 = rise.mapSeq #rise.nat<4> #rise.array<4, array<4, array<4, scalar<f32>>>> #rise.array<4, array<4, array<4, scalar<f32>>>>
+        %mapInnerLambda_1 = rise.lambda (%arraySlice_1 : !rise.array<4, array<4, array<4, scalar<f32>>>>) -> !rise.array<4, array<4, array<4, scalar<f32>>>> {
+            %map2 = rise.mapSeq #rise.nat<4> #rise.array<4, array<4, scalar<f32>>> #rise.array<4, array<4, scalar<f32>>>
+            %mapInnerLambda_2 = rise.lambda (%arraySlice_2 : !rise.array<4, array<4, scalar<f32>>>) -> !rise.array<4, array<4, scalar<f32>>> {
+                %map3 = rise.mapSeq #rise.nat<4> #rise.array<4, scalar<f32>> #rise.array<4, scalar<f32>>
+                    %mapInnerLambda_3 = rise.lambda (%arraySlice_3 : !rise.array<4, scalar<f32>>) -> !rise.array<4, scalar<f32>> {
+                        %map4 = rise.mapSeq #rise.nat<4> #rise.scalar<f32> #rise.scalar<f32>
+                        %res = rise.apply %map4, %doubleFun, %arraySlice_3
+                        rise.return %res : !rise.array<4, scalar<f32>>
+                    }
+                %res = rise.apply %map3, %mapInnerLambda_3, %arraySlice_2
+                rise.return %res : !rise.array<4, array<4, scalar<f32>>>
+            }
+           %res = rise.apply %map2, %mapInnerLambda_2, %arraySlice_1
+           rise.return %res : !rise.array<4, array<4, array<4, scalar<f32>>>>
+        }
+        %res = rise.apply %map1, %mapInnerLambda_1, %array4D
+        rise.out %outArg <- %res
+        rise.return
     }
-    %res = rise.apply %map1, %mapInnerLambda_1, %array4D
-    rise.out %outArg <- %res
     return
 }
 func @mapMapId() {

--- a/mlir/test/Conversion/RiseToImperative/add_tuples.mlir
+++ b/mlir/test/Conversion/RiseToImperative/add_tuples.mlir
@@ -2,28 +2,31 @@
 
 func @print_memref_f32(memref<*xf32>)
 func @rise_fun(%outArg:memref<4xf32>, %inArg0:memref<4xf32>, %inArg1:memref<4xf32>) {
-    %array0 = rise.in %inArg0 : !rise.array<4, scalar<f32>>
-    %array1 = rise.in %inArg1 : !rise.array<4, scalar<f32>>
+    rise.lowering_unit {
+        %array0 = rise.in %inArg0 : !rise.array<4, scalar<f32>>
+        %array1 = rise.in %inArg1 : !rise.array<4, scalar<f32>>
 
-    %zipFun = rise.zip #rise.nat<4> #rise.scalar<f32> #rise.scalar<f32>
-    %zipped = rise.apply %zipFun, %array0, %array1
+        %zipFun = rise.zip #rise.nat<4> #rise.scalar<f32> #rise.scalar<f32>
+        %zipped = rise.apply %zipFun, %array0, %array1
 
-    %tupleAddFun = rise.lambda (%floatTuple : !rise.tuple<scalar<f32>, scalar<f32>>) -> !rise.scalar<f32> {
-        %fstFun = rise.fst #rise.scalar<f32> #rise.scalar<f32>
-        %sndFun = rise.snd #rise.scalar<f32> #rise.scalar<f32>
+        %tupleAddFun = rise.lambda (%floatTuple : !rise.tuple<scalar<f32>, scalar<f32>>) -> !rise.scalar<f32> {
+            %fstFun = rise.fst #rise.scalar<f32> #rise.scalar<f32>
+            %sndFun = rise.snd #rise.scalar<f32> #rise.scalar<f32>
 
-        %fst = rise.apply %fstFun, %floatTuple
-        %snd = rise.apply %sndFun, %floatTuple
-        %result = rise.embed(%fst, %snd) {
-            %result = addf %fst, %snd : f32
-            rise.return %result : f32
-        } : !rise.scalar<f32>
-        rise.return %result : !rise.scalar<f32>
+            %fst = rise.apply %fstFun, %floatTuple
+            %snd = rise.apply %sndFun, %floatTuple
+            %result = rise.embed(%fst, %snd) {
+                %result = addf %fst, %snd : f32
+                rise.return %result : f32
+            } : !rise.scalar<f32>
+            rise.return %result : !rise.scalar<f32>
+        }
+
+        %mapFun = rise.mapSeq #rise.nat<4> #rise.tuple<scalar<f32>, scalar<f32>> #rise.scalar<f32>
+        %sumArray = rise.apply %mapFun, %tupleAddFun, %zipped
+        rise.out %outArg <- %sumArray
+        rise.return
     }
-
-    %mapFun = rise.mapSeq #rise.nat<4> #rise.tuple<scalar<f32>, scalar<f32>> #rise.scalar<f32>
-    %sumArray = rise.apply %mapFun, %tupleAddFun, %zipped
-    rise.out %outArg <- %sumArray
     return
 }
 func @simple_add_tuples() {

--- a/mlir/test/Conversion/RiseToImperative/fst.mlir
+++ b/mlir/test/Conversion/RiseToImperative/fst.mlir
@@ -2,21 +2,24 @@
 
 func @print_memref_f32(memref<*xf32>)
 func @rise_fun(%outArg:memref<4xf32>, %inArg0:memref<4xf32>, %inArg1:memref<4xf32>) {
-    %array0 = rise.in %inArg0 : !rise.array<4, scalar<f32>>
-    %array1 = rise.in %inArg1 : !rise.array<4, scalar<f32>>
+    rise.lowering_unit {
+        %array0 = rise.in %inArg0 : !rise.array<4, scalar<f32>>
+        %array1 = rise.in %inArg1 : !rise.array<4, scalar<f32>>
 
-    %zipFun = rise.zip #rise.nat<4> #rise.scalar<f32> #rise.scalar<f32>
-    %zipped = rise.apply %zipFun, %array0, %array1
+        %zipFun = rise.zip #rise.nat<4> #rise.scalar<f32> #rise.scalar<f32>
+        %zipped = rise.apply %zipFun, %array0, %array1
 
-    %projectToFirst = rise.lambda (%floatTuple : !rise.tuple<scalar<f32>, scalar<f32>>) -> !rise.scalar<f32> {
-        %fstFun = rise.fst #rise.scalar<f32> #rise.scalar<f32>
-        %fst = rise.apply %fstFun, %floatTuple
-        rise.return %fst : !rise.scalar<f32>
+        %projectToFirst = rise.lambda (%floatTuple : !rise.tuple<scalar<f32>, scalar<f32>>) -> !rise.scalar<f32> {
+            %fstFun = rise.fst #rise.scalar<f32> #rise.scalar<f32>
+            %fst = rise.apply %fstFun, %floatTuple
+            rise.return %fst : !rise.scalar<f32>
+        }
+
+        %mapFun = rise.mapSeq #rise.nat<4> #rise.tuple<scalar<f32>, scalar<f32>> #rise.scalar<f32>
+        %fstArray = rise.apply %mapFun, %projectToFirst, %zipped
+        rise.out %outArg <- %fstArray
+        rise.return
     }
-
-    %mapFun = rise.mapSeq #rise.nat<4> #rise.tuple<scalar<f32>, scalar<f32>> #rise.scalar<f32>
-    %fstArray = rise.apply %mapFun, %projectToFirst, %zipped
-    rise.out %outArg <- %fstArray
     return
 }
 

--- a/mlir/test/Conversion/RiseToImperative/map_map_add.mlir
+++ b/mlir/test/Conversion/RiseToImperative/map_map_add.mlir
@@ -2,6 +2,7 @@
 
 func @print_memref_f32(memref<*xf32>)
 func @rise_fun(%outArg:memref<4x4xf32>, %inArg:memref<4x4xf32>) {
+    rise.lowering_unit {
         %array2D = rise.in %inArg : !rise.array<4, array<4, scalar<f32>>>
         %mapInnerLambda = rise.lambda (%arraySlice : !rise.array<4, scalar<f32>>) -> !rise.array<4, scalar<f32>> {
            %doubleFun = rise.lambda (%summand : !rise.scalar<f32>) -> !rise.scalar<f32> {
@@ -18,7 +19,9 @@ func @rise_fun(%outArg:memref<4x4xf32>, %inArg:memref<4x4xf32>) {
         %map1 = rise.mapSeq #rise.nat<4> #rise.array<4, scalar<f32>> #rise.array<4, scalar<f32>>
         %res = rise.apply %map1, %mapInnerLambda, %array2D
         rise.out %outArg <- %res
-        return
+        rise.return
+    }
+    return
 }
 func @mapMapId() {
 

--- a/mlir/test/Conversion/RiseToImperative/map_mul.mlir
+++ b/mlir/test/Conversion/RiseToImperative/map_mul.mlir
@@ -2,18 +2,21 @@
 
 func @print_memref_f32(memref<*xf32>)
 func @rise_fun(%outArg:memref<4xf32>, %in:memref<4xf32>) {
-    %array = rise.in %in : !rise.array<4, scalar<f32>>
-    %times5 = rise.lambda (%elem : !rise.scalar<f32>) -> !rise.scalar<f32> {
-        %cst5 = rise.literal #rise.lit<5.0>
-        %result = rise.embed(%elem, %cst5) {
-            %result = mulf %elem, %cst5 : f32
-            rise.return %result : f32
-        } : !rise.scalar<f32>
-        rise.return %result : !rise.scalar<f32>
+    rise.lowering_unit {
+        %array = rise.in %in : !rise.array<4, scalar<f32>>
+        %times5 = rise.lambda (%elem : !rise.scalar<f32>) -> !rise.scalar<f32> {
+            %cst5 = rise.literal #rise.lit<5.0>
+            %result = rise.embed(%elem, %cst5) {
+                %result = mulf %elem, %cst5 : f32
+                rise.return %result : f32
+            } : !rise.scalar<f32>
+            rise.return %result : !rise.scalar<f32>
+        }
+        %mapFun = rise.mapSeq #rise.nat<4> #rise.scalar<f32> #rise.scalar<f32>
+        %multipliedArray = rise.apply %mapFun, %times5, %array
+        rise.out %outArg <- %multipliedArray
+        rise.return
     }
-    %mapFun = rise.mapSeq #rise.nat<4> #rise.scalar<f32> #rise.scalar<f32>
-    %multipliedArray = rise.apply %mapFun, %times5, %array
-    rise.out %outArg <- %multipliedArray
     return
 }
 func @array_times_5() {

--- a/mlir/test/Conversion/RiseToImperative/map_slide_reduce.mlir
+++ b/mlir/test/Conversion/RiseToImperative/map_slide_reduce.mlir
@@ -2,39 +2,40 @@
 
 func @print_memref_f32(memref<*xf32>)
 func @rise_fun(%outArg:memref<9x7xf32>, %inA:memref<9x9xf32>) {
+    rise.lowering_unit {
+        %A = rise.in %inA : !rise.array<9, array<9, scalar<f32>>>
 
-    %A = rise.in %inA : !rise.array<9, array<9, scalar<f32>>>
+        %slideLambda = rise.lambda (%arr : !rise.array<9, scalar<f32>>) -> !rise.array<7, array<3, scalar<f32>>> {
+            %slide = rise.slide #rise.nat<7> #rise.nat<3> #rise.nat<1> #rise.scalar<f32> // what does n here mean?
+            %slizzled = rise.apply %slide, %arr
+            rise.return %slizzled : !rise.array<7, array<3, scalar<f32>>>
+        }
+        %map = rise.map #rise.nat<9> #rise.array<9, scalar<f32>> #rise.array<7, array<3, scalar<f32>>>
+        %slidemapped = rise.apply %map, %slideLambda, %A
 
-
-    %slideLambda = rise.lambda (%arr : !rise.array<9, scalar<f32>>) -> !rise.array<7, array<3, scalar<f32>>> {
-        %slide = rise.slide #rise.nat<7> #rise.nat<3> #rise.nat<1> #rise.scalar<f32> // what does n here mean?
-        %slizzled = rise.apply %slide, %arr
-        rise.return %slizzled : !rise.array<7, array<3, scalar<f32>>>
-    }
-    %map = rise.map #rise.nat<9> #rise.array<9, scalar<f32>> #rise.array<7, array<3, scalar<f32>>>
-    %slidemapped = rise.apply %map, %slideLambda, %A
-
-    %mapLambda = rise.lambda (%array : !rise.array<7, array<3, scalar<f32>>>) -> !rise.array<7, scalar<f32>> {
-        %reduceWindow = rise.lambda (%window : !rise.array<3, scalar<f32>>) -> !rise.scalar<f32> {
-            %reductionAdd = rise.lambda (%summand0 : !rise.scalar<f32>, %summand1 : !rise.scalar<f32>) -> !rise.scalar<f32> {
-                %result = rise.embed(%summand0, %summand1) {
-                    %result = addf %summand0, %summand1 : f32
-                    rise.return %result : f32
-                } : !rise.scalar<f32>
+        %mapLambda = rise.lambda (%array : !rise.array<7, array<3, scalar<f32>>>) -> !rise.array<7, scalar<f32>> {
+            %reduceWindow = rise.lambda (%window : !rise.array<3, scalar<f32>>) -> !rise.scalar<f32> {
+                %reductionAdd = rise.lambda (%summand0 : !rise.scalar<f32>, %summand1 : !rise.scalar<f32>) -> !rise.scalar<f32> {
+                    %result = rise.embed(%summand0, %summand1) {
+                        %result = addf %summand0, %summand1 : f32
+                        rise.return %result : f32
+                    } : !rise.scalar<f32>
+                    rise.return %result : !rise.scalar<f32>
+                }
+                %initializer = rise.literal #rise.lit<0.0>
+                %reduce = rise.reduceSeq #rise.nat<3> #rise.scalar<f32> #rise.scalar<f32>
+                %result = rise.apply %reduce, %reductionAdd, %initializer, %window
                 rise.return %result : !rise.scalar<f32>
             }
-            %initializer = rise.literal #rise.lit<0.0>
-            %reduce = rise.reduceSeq #rise.nat<3> #rise.scalar<f32> #rise.scalar<f32>
-            %result = rise.apply %reduce, %reductionAdd, %initializer, %window
-            rise.return %result : !rise.scalar<f32>
+            %mapReduce = rise.mapSeq {to = "affine"}  #rise.nat<7> #rise.array<3, scalar<f32>> #rise.scalar<f32>
+            %result = rise.apply %mapReduce, %reduceWindow, %array
+            rise.return %result : !rise.array<7, scalar<f32>>
         }
-        %mapReduce = rise.mapSeq {to = "affine"}  #rise.nat<7> #rise.array<3, scalar<f32>> #rise.scalar<f32>
-        %result = rise.apply %mapReduce, %reduceWindow, %array
-        rise.return %result : !rise.array<7, scalar<f32>>
+        %mapOuter = rise.mapSeq {to = "affine"}  #rise.nat<9> #rise.array<7, array<3, scalar<f32>>> #rise.array<7, scalar<f32>>
+        %result = rise.apply %mapOuter, %mapLambda, %slidemapped
+        rise.out %outArg <- %result
+        rise.return
     }
-    %mapOuter = rise.mapSeq {to = "affine"}  #rise.nat<9> #rise.array<7, array<3, scalar<f32>>> #rise.array<7, scalar<f32>>
-    %result = rise.apply %mapOuter, %mapLambda, %slidemapped
-    rise.out %outArg <- %result
     return
 }
 func @rtclock() -> (f64)

--- a/mlir/test/Conversion/RiseToImperative/mm.mlir
+++ b/mlir/test/Conversion/RiseToImperative/mm.mlir
@@ -7,7 +7,7 @@ func @rise_fun(%outArg:memref<4x4xf32>, %inA:memref<4x4xf32>, %inB:memref<4x4xf3
         %B = rise.in %inB : !rise.array<4, array<4, scalar<f32>>>
 
         %f1 = rise.lambda (%arow : !rise.array<4, scalar<f32>>) -> !rise.array<4, scalar<f32>> {
-            %f2 = rise.lambda (%bcol : !rise.array<4, scalar<f32>>) -> !rise.array<4, scalar<f32>> {
+            %f2 = rise.lambda (%bcol : !rise.array<4, scalar<f32>>) -> !rise.scalar<f32> {
 
                 //Zipping
                 %zipFun = rise.zip #rise.nat<4> #rise.scalar<f32> #rise.scalar<f32>
@@ -44,9 +44,9 @@ func @rise_fun(%outArg:memref<4x4xf32>, %inA:memref<4x4xf32>, %inB:memref<4x4xf3
 
                 rise.return %result : !rise.scalar<f32>
             }
-            %m2 = rise.mapPar #rise.nat<4> #rise.array<4, scalar<f32>> #rise.array<4, scalar<f32>>
+            %m2 = rise.mapPar #rise.nat<4> #rise.array<4, scalar<f32>> #rise.scalar<f32>
             %result = rise.apply %m2, %f2, %B
-            rise.return %result : !rise.array<4, array<4, scalar<f32>>>
+            rise.return %result : !rise.array<4, scalar<f32>>
         }
         %m1 = rise.mapPar #rise.nat<4> #rise.array<4, scalar<f32>> #rise.array<4, scalar<f32>>
         %result = rise.apply %m1, %f1, %A

--- a/mlir/test/Conversion/RiseToImperative/mm_fused.mlir
+++ b/mlir/test/Conversion/RiseToImperative/mm_fused.mlir
@@ -16,7 +16,7 @@ func @rise_fun(%outArg:memref<2048x2048xf32>, %inA:memref<2048x2048xf32>, %inB:m
 
 
         %m1fun = rise.lambda (%arow : !rise.array<2048, scalar<f32>>) -> !rise.array<2048, scalar<f32>> {
-            %m2fun = rise.lambda (%bcol : !rise.array<2048, scalar<f32>>) -> !rise.array<2048, scalar<f32>> {
+            %m2fun = rise.lambda (%bcol : !rise.array<2048, scalar<f32>>) -> !rise.scalar<f32> {
 
                 //Zipping
                 %zipFun = rise.zip #rise.nat<2048> #rise.scalar<f32> #rise.scalar<f32>
@@ -45,9 +45,9 @@ func @rise_fun(%outArg:memref<2048x2048xf32>, %inA:memref<2048x2048xf32>, %inB:m
 
                 rise.return %result : !rise.scalar<f32>
             }
-            %m2 = rise.mapSeq {to = "affine"}  #rise.nat<2048> #rise.array<2048, scalar<f32>> #rise.array<2048, scalar<f32>>
+            %m2 = rise.mapSeq {to = "affine"}  #rise.nat<2048> #rise.array<2048, scalar<f32>> #rise.scalar<f32>
             %result = rise.apply %m2, %m2fun, %B_trans
-            rise.return %result : !rise.array<2048, array<2048, scalar<f32>>>
+            rise.return %result : !rise.array<2048, scalar<f32>>
         }
         %m1 = rise.mapSeq {to = "affine"}  #rise.nat<2048> #rise.array<2048, scalar<f32>> #rise.array<2048, scalar<f32>>
         %result = rise.apply %m1, %m1fun, %A

--- a/mlir/test/Conversion/RiseToImperative/mm_irregular.mlir
+++ b/mlir/test/Conversion/RiseToImperative/mm_irregular.mlir
@@ -10,8 +10,8 @@ func @rise_fun(%outArg:memref<10x5xf32>, %inA:memref<10x2xf32>, %inB:memref<2x5x
         %transpose = rise.transpose #rise.nat<2> #rise.nat<5> #rise.scalar<f32>
         %B_trans = rise.apply %transpose, %B
 
-        %m1fun = rise.lambda (%arow : !rise.array<2, scalar<f32>>) -> !rise.array<2, scalar<f32>> {
-            %m2fun = rise.lambda (%bcol : !rise.array<2, scalar<f32>>) -> !rise.array<2, scalar<f32>> {
+        %m1fun = rise.lambda (%arow : !rise.array<2, scalar<f32>>) -> !rise.array<5, scalar<f32>> {
+            %m2fun = rise.lambda (%bcol : !rise.array<2, scalar<f32>>) -> !rise.scalar<f32> {
 
                 //Zipping
                 %zipFun = rise.zip #rise.nat<2> #rise.scalar<f32> #rise.scalar<f32>
@@ -40,11 +40,11 @@ func @rise_fun(%outArg:memref<10x5xf32>, %inA:memref<10x2xf32>, %inB:memref<2x5x
 
                 rise.return %result : !rise.scalar<f32>
             }
-            %m2 = rise.mapSeq {to = "affine"}  #rise.nat<5> #rise.array<2, scalar<f32>> #rise.array<2, scalar<f32>>
+            %m2 = rise.mapSeq {to = "affine"}  #rise.nat<5> #rise.array<2, scalar<f32>> #rise.scalar<f32>
             %result = rise.apply %m2, %m2fun, %B_trans
-            rise.return %result : !rise.array<5, array<2, scalar<f32>>>
+            rise.return %result : !rise.array<5, scalar<f32>>
         }
-        %m1 = rise.mapSeq {to = "affine"}  #rise.nat<10> #rise.array<2, scalar<f32>> #rise.array<2, scalar<f32>>
+        %m1 = rise.mapSeq {to = "affine"}  #rise.nat<10> #rise.array<2, scalar<f32>> #rise.array<5, scalar<f32>>
         %result = rise.apply %m1, %m1fun, %A
         rise.out %outArg <- %result
         rise.return

--- a/mlir/test/Conversion/RiseToImperative/multiple_lowering_units.mlir
+++ b/mlir/test/Conversion/RiseToImperative/multiple_lowering_units.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s -convert-rise-to-imperative -convert-linalg-to-loops -lower-affine -convert-scf-to-std -convert-std-to-llvm | mlir-cpu-runner -e array_times_2 -entry-point-result=void -shared-libs=%linalg_test_lib_dir/libmlir_runner_utils%shlibext  | FileCheck %s --check-prefix=ARRAY_TIMES_2
+// RUN: mlir-opt %s -convert-rise-to-imperative -convert-rise-to-imperative -convert-linalg-to-loops -lower-affine -convert-scf-to-std -convert-std-to-llvm | mlir-cpu-runner -e multiple -entry-point-result=void -shared-libs=%linalg_test_lib_dir/libmlir_runner_utils%shlibext  | FileCheck %s --check-prefix=MULTIPLE
 
 func @print_memref_f32(memref<*xf32>)
 
@@ -18,10 +18,25 @@ func @rise_fun(%outArg: memref<6xf32>, %in: memref<6xf32>) {
         rise.out %outArg <- %doubledArray
         rise.return
     }
+    rise.lowering_unit {
+        %array = rise.in %outArg : !rise.array<6, scalar<f32>>
+
+        %doubleFun = rise.lambda (%summand : !rise.scalar<f32>) -> !rise.scalar<f32> {
+            %result = rise.embed(%summand) {
+                %doubled = addf %summand, %summand : f32
+                rise.return %doubled : f32
+            } : !rise.scalar<f32>
+            rise.return %result : !rise.scalar<f32>
+        }
+        %map = rise.mapSeq {to = "scf"} #rise.nat<6> #rise.scalar<f32> #rise.scalar<f32>
+        %doubledArray = rise.apply %map, %doubleFun, %array
+        rise.out %outArg <- %doubledArray
+        rise.return
+    }
     return
 }
 
-func @array_times_2() {
+func @multiple() {
     //prepare output Array
     %outputArray = alloc() : memref<6xf32>
 
@@ -35,6 +50,6 @@ func @array_times_2() {
     call @print_memref_f32(%print_me): (memref<*xf32>) -> ()
     return
 }
-// ARRAY_TIMES_2: Memref base@ = {{.*}} rank = 1 offset = 0 sizes = [6] strides = [1] data =
-// ARRAY_TIMES_2: [10, 10, 10, 10, 10, 10]
+// MULTIPLE: Memref base@ = {{.*}} rank = 1 offset = 0 sizes = [6] strides = [1] data =
+// MULTIPLE: [20, 20, 20, 20, 20, 20]
 

--- a/mlir/test/Conversion/RiseToImperative/pad.mlir
+++ b/mlir/test/Conversion/RiseToImperative/pad.mlir
@@ -3,22 +3,25 @@
 func @print_memref_f32(memref<*xf32>)
 
 func @rise_fun(%outArg: memref<14xf32>, %in: memref<9xf32>) {
-    %array = rise.in %in : !rise.array<9, scalar<f32>>
+    rise.lowering_unit {
+        %array = rise.in %in : !rise.array<9, scalar<f32>>
 
-    %pad = rise.pad #rise.nat<9> #rise.nat<2> #rise.nat<3> #rise.scalar<f32>
-    %padded = rise.apply %pad, %array
+        %pad = rise.pad #rise.nat<9> #rise.nat<2> #rise.nat<3> #rise.scalar<f32>
+        %padded = rise.apply %pad, %array
 
-    %doubleFun = rise.lambda (%summand : !rise.scalar<f32>) -> !rise.scalar<f32> {
-        %result = rise.embed(%summand) {
-            %doubled = addf %summand, %summand : f32
-            rise.return %doubled : f32
-        } : !rise.scalar<f32>
-        rise.return %result : !rise.scalar<f32>
+        %doubleFun = rise.lambda (%summand : !rise.scalar<f32>) -> !rise.scalar<f32> {
+            %result = rise.embed(%summand) {
+                %doubled = addf %summand, %summand : f32
+                rise.return %doubled : f32
+            } : !rise.scalar<f32>
+            rise.return %result : !rise.scalar<f32>
+        }
+        %map = rise.mapSeq {to = "scf"} #rise.nat<14> #rise.scalar<f32> #rise.scalar<f32>
+        %result = rise.apply %map, %doubleFun, %padded
+
+        rise.out %outArg <- %result
+        rise.return
     }
-    %map = rise.mapSeq {to = "scf"} #rise.nat<14> #rise.scalar<f32> #rise.scalar<f32>
-    %result = rise.apply %map, %doubleFun, %padded
-
-    rise.out %outArg <- %result
     return
 }
 

--- a/mlir/test/Conversion/RiseToImperative/reduce.mlir
+++ b/mlir/test/Conversion/RiseToImperative/reduce.mlir
@@ -1,19 +1,22 @@
 // RUN: mlir-opt %s -convert-rise-to-imperative -convert-linalg-to-loops -convert-linalg-to-std -lower-affine -convert-scf-to-std -convert-std-to-llvm | mlir-cpu-runner -e simple_reduction -entry-point-result=void -shared-libs=%linalg_test_lib_dir/libmlir_runner_utils%shlibext  | FileCheck %s --check-prefix=SIMPLE_1D_REDUCTION
 func @print_memref_f32(memref<*xf32>)
 func @rise_fun(%outArg:memref<f32>, %inArg:memref<1024xf32>) {
-    %array0 = rise.in %inArg : !rise.array<1024, scalar<f32>>
+    rise.lowering_unit {
+        %array0 = rise.in %inArg : !rise.array<1024, scalar<f32>>
 
-    %reductionAdd = rise.lambda (%summand0 : !rise.scalar<f32>, %summand1 : !rise.scalar<f32>) -> !rise.scalar<f32> {
-        %result = rise.embed(%summand0, %summand1) {
-            %result = addf %summand0, %summand1 : f32
-            rise.return %result : f32
-        } : !rise.scalar<f32>
-        rise.return %result : !rise.scalar<f32>
+        %reductionAdd = rise.lambda (%summand0 : !rise.scalar<f32>, %summand1 : !rise.scalar<f32>) -> !rise.scalar<f32> {
+            %result = rise.embed(%summand0, %summand1) {
+                %result = addf %summand0, %summand1 : f32
+                rise.return %result : f32
+            } : !rise.scalar<f32>
+            rise.return %result : !rise.scalar<f32>
+        }
+        %initializer = rise.literal #rise.lit<0.0>
+        %reduce4Ints = rise.reduceSeq #rise.nat<1024> #rise.scalar<f32> #rise.scalar<f32>
+        %result = rise.apply %reduce4Ints, %reductionAdd, %initializer, %array0
+        rise.out %outArg <- %result
+        rise.return
     }
-    %initializer = rise.literal #rise.lit<0.0>
-    %reduce4Ints = rise.reduceSeq #rise.nat<1024> #rise.scalar<f32> #rise.scalar<f32>
-    %result = rise.apply %reduce4Ints, %reductionAdd, %initializer, %array0
-    rise.out %outArg <- %result
     return
 }
 

--- a/mlir/test/Conversion/RiseToImperative/snd.mlir
+++ b/mlir/test/Conversion/RiseToImperative/snd.mlir
@@ -2,21 +2,24 @@
 
 func @print_memref_f32(memref<*xf32>)
 func @rise_fun(%outArg:memref<4xf32>, %inArg0:memref<4xf32>, %inArg1:memref<4xf32>) {
-    %array0 = rise.in %inArg0 : !rise.array<4, scalar<f32>>
-    %array1 = rise.in %inArg1 : !rise.array<4, scalar<f32>>
+    rise.lowering_unit {
+        %array0 = rise.in %inArg0 : !rise.array<4, scalar<f32>>
+        %array1 = rise.in %inArg1 : !rise.array<4, scalar<f32>>
 
-    %zipFun = rise.zip #rise.nat<4> #rise.scalar<f32> #rise.scalar<f32>
-    %zipped = rise.apply %zipFun, %array0, %array1
+        %zipFun = rise.zip #rise.nat<4> #rise.scalar<f32> #rise.scalar<f32>
+        %zipped = rise.apply %zipFun, %array0, %array1
 
-    %projectToFirst = rise.lambda (%floatTuple : !rise.tuple<scalar<f32>, scalar<f32>>) -> !rise.scalar<f32> {
-        %sndFun = rise.snd #rise.scalar<f32> #rise.scalar<f32>
-        %snd = rise.apply %sndFun, %floatTuple
-        rise.return %snd : !rise.scalar<f32>
+        %projectToFirst = rise.lambda (%floatTuple : !rise.tuple<scalar<f32>, scalar<f32>>) -> !rise.scalar<f32> {
+            %sndFun = rise.snd #rise.scalar<f32> #rise.scalar<f32>
+            %snd = rise.apply %sndFun, %floatTuple
+            rise.return %snd : !rise.scalar<f32>
+        }
+
+        %mapFun = rise.mapSeq #rise.nat<4> #rise.tuple<scalar<f32>, scalar<f32>> #rise.scalar<f32>
+        %fstArray = rise.apply %mapFun, %projectToFirst, %zipped
+        rise.out %outArg <- %fstArray
+        rise.return
     }
-
-    %mapFun = rise.mapSeq #rise.nat<4> #rise.tuple<scalar<f32>, scalar<f32>> #rise.scalar<f32>
-    %fstArray = rise.apply %mapFun, %projectToFirst, %zipped
-    rise.out %outArg <- %fstArray
     return
 }
 

--- a/mlir/test/Conversion/RiseToImperative/split.mlir
+++ b/mlir/test/Conversion/RiseToImperative/split.mlir
@@ -3,6 +3,7 @@
 func @print_memref_f32(memref<*xf32>)
 
 func @rise_fun(%outArg: memref<6xf32>, %in: memref<6xf32>) {
+    rise.lowering_unit {
         %array = rise.in %in : !rise.array<6, scalar<f32>>
 
         %split = rise.split #rise.nat<2> #rise.nat<3> #rise.scalar<f32>
@@ -26,7 +27,9 @@ func @rise_fun(%outArg: memref<6xf32>, %in: memref<6xf32>) {
         %join = rise.join #rise.nat<3> #rise.nat<2> #rise.scalar<f32>
         %flattened = rise.apply %join, %res
         rise.out %outArg <- %flattened
-        return
+        rise.return
+    }
+    return
 }
 
 func @array_times_2() {

--- a/mlir/test/lib/Dialect/Rise/rise_highlevel_test.cpp
+++ b/mlir/test/lib/Dialect/Rise/rise_highlevel_test.cpp
@@ -109,121 +109,162 @@ TEST_FUNC(declare_functions) {
   printBinOp.erase();
 }
 
-TEST_FUNC(build_and_lower_matrix_multiplication) {
-  // A:MxN * B:NxK = C:MxK
-  int64_t M = 32;
-  int64_t N = 16;
-  int64_t K = 64;
+//TEST_FUNC(build_and_lower_matrix_multiplication) {
+//  // A:MxN * B:NxK = C:MxK
+//  int64_t M = 32;
+//  int64_t N = 16;
+//  int64_t K = 64;
+//
+//  auto f32Type = FloatType::getF32(&globalContext());
+//
+//  auto f = makeFunction("mm", {},
+//                        {MemRefType::get({M, N}, f32Type, {}, 0),
+//                         MemRefType::get({N, K}, f32Type, {}, 0),
+//                         MemRefType::get({M, K}, f32Type, {}, 0)});
+//
+//  OpBuilder builder(f.getBody());
+//  ScopedContext scope(builder, f.getLoc());
+//
+//  Value A = f.getArgument(0);
+//  Value B = f.getArgument(1);
+//  Value C = f.getArgument(2);
+//
+//  makeRiseProgram(A, B, C, [&](Value A, Value B) {
+//    return mlir::edsc::highlevel::matrix_multiplication(M, N, K, A, B);
+//  });
+//  std_ret();
+//
+//  // clang-format off
+//  // IMPERATIVE:       module {
+//  // IMPERATIVE-LABEL:   func @mm(
+//  // IMPERATIVE-SAME:             %[[VAL_0:.*]]: memref<32x16xf32>, %[[VAL_1:.*]]: memref<16x64xf32>, %[[VAL_2:.*]]: memref<32x64xf32>) {
+//  // IMPERATIVE:           %[[VAL_3:.*]] = constant 32 : index
+//  // IMPERATIVE:           %[[VAL_4:.*]] = constant 64 : index
+//  // IMPERATIVE:           %[[VAL_5:.*]] = constant 0.000000e+00 : f32
+//  // IMPERATIVE:           %[[VAL_6:.*]] = constant 0 : index
+//  // IMPERATIVE:           %[[VAL_7:.*]] = constant 16 : index
+//  // IMPERATIVE:           %[[VAL_8:.*]] = constant 1 : index
+//  // IMPERATIVE:           scf.for %[[VAL_9:.*]] = %[[VAL_6]] to %[[VAL_3]] step %[[VAL_8]] {
+//  // IMPERATIVE:             scf.for %[[VAL_10:.*]] = %[[VAL_6]] to %[[VAL_4]] step %[[VAL_8]] {
+//  // IMPERATIVE:               store %[[VAL_5]], %[[VAL_2]]{{\[}}%[[VAL_9]], %[[VAL_10]]] : memref<32x64xf32>
+//  // IMPERATIVE:               scf.for %[[VAL_11:.*]] = %[[VAL_6]] to %[[VAL_7]] step %[[VAL_8]] {
+//  // IMPERATIVE:                 %[[VAL_12:.*]] = load %[[VAL_0]]{{\[}}%[[VAL_9]], %[[VAL_11]]] : memref<32x16xf32>
+//  // IMPERATIVE:                 %[[VAL_13:.*]] = load %[[VAL_1]]{{\[}}%[[VAL_11]], %[[VAL_10]]] : memref<16x64xf32>
+//  // IMPERATIVE:                 %[[VAL_14:.*]] = load %[[VAL_2]]{{\[}}%[[VAL_9]], %[[VAL_10]]] : memref<32x64xf32>
+//  // IMPERATIVE:                 %[[VAL_15:.*]] = addf %[[VAL_12]], %[[VAL_13]] : f32
+//  // IMPERATIVE:                 %[[VAL_16:.*]] = mulf %[[VAL_14]], %[[VAL_15]] : f32
+//  // IMPERATIVE:                 store %[[VAL_16]], %[[VAL_2]]{{\[}}%[[VAL_9]], %[[VAL_10]]] : memref<32x64xf32>
+//  // IMPERATIVE:               }
+//  // IMPERATIVE:             }
+//  // IMPERATIVE:           }
+//  // IMPERATIVE:           return
+//  // IMPERATIVE:         }
+//  // clang-format on
+//
+//  f.print(llvm::outs());
+//  f.erase();
+//}
+//
+//TEST_FUNC(test_conv2) {
+//  int64_t width = 9;
+//  int64_t height = 9;
+//  int64_t kernelWidth = 3;
+//  int64_t kernelHeight = 3;
+//  auto f32Type = FloatType::getF32(&globalContext());
+//
+//  auto f = makeFunction(
+//      "conv2D", {},
+//      {MemRefType::get({height, width}, f32Type, {}, 0),
+//       MemRefType::get({kernelHeight, kernelWidth}, f32Type, {}, 0),
+//       MemRefType::get({height, width}, f32Type, {}, 0)});
+//
+//  OpBuilder builder(f.getBody());
+//  ScopedContext scope(builder, f.getLoc());
+//
+//  Value A = f.getArgument(0);
+//  Value kernel = f.getArgument(1);
+//  Value output = f.getArgument(2);
+//
+//  makeRiseProgram(A, kernel, output,
+//                  [](Value A, Value kernel) { return conv2D(A, kernel); });
+//
+//  std_ret();
+//
+//  // generate test
+//  auto testFun = makeFunction("conv2D_test", {}, {});
+//  OpBuilder test_builder(testFun.getBody());
+//  ScopedContext test_scope(test_builder, testFun.getLoc());
+//  mlir::edsc::highlevel::generateTest(
+//      2, {height, width}, {kernelHeight, kernelWidth}, {height, width}, f);
+//  std_ret();
+//  // clang-format off
+//  // CONV_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [9, 9] strides = [9, 1] data =
+//  // CONV_2D_TEST:       {{\[\[}}1,   2,   3,   4,   5,   6,   7,   8,   9],
+//  // CONV_2D_TEST:        [10,   11,   12,   13,   14,   15,   16,   17,   18],
+//  // CONV_2D_TEST:        [19,   20,   21,   22,   23,   24,   25,   26,   27],
+//  // CONV_2D_TEST:        [28,   29,   30,   31,   32,   33,   34,   35,   36],
+//  // CONV_2D_TEST:        [37,   38,   39,   40,   41,   42,   43,   44,   45],
+//  // CONV_2D_TEST:        [46,   47,   48,   49,   50,   51,   52,   53,   54],
+//  // CONV_2D_TEST:        [55,   56,   57,   58,   59,   60,   61,   62,   63],
+//  // CONV_2D_TEST:        [64,   65,   66,   67,   68,   69,   70,   71,   72],
+//  // CONV_2D_TEST:        [73,   74,   75,   76,   77,   78,   79,   80,   81]]
+//  // CONV_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [3, 3] strides = [3, 1] data =
+//  // CONV_2D_TEST:       {{\[\[}}1,   1,   1],
+//  // CONV_2D_TEST:        [1,   1,   1],
+//  // CONV_2D_TEST:        [1,   1,   1]]
+//  // CONV_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [9, 9] strides = [9, 1] data =
+//  // CONV_2D_TEST:       {{\[\[}}39,   45,   54,   63,   72,   81,   90,   99,   105],
+//  // CONV_2D_TEST:        [93,   99,   108,   117,   126,   135,   144,   153,   159],
+//  // CONV_2D_TEST:        [174,   180,   189,   198,   207,   216,   225,   234,   240],
+//  // CONV_2D_TEST:        [255,   261,   270,   279,   288,   297,   306,   315,   321],
+//  // CONV_2D_TEST:        [336,   342,   351,   360,   369,   378,   387,   396,   402],
+//  // CONV_2D_TEST:        [417,   423,   432,   441,   450,   459,   468,   477,   483],
+//  // CONV_2D_TEST:        [498,   504,   513,   522,   531,   540,   549,   558,   564],
+//  // CONV_2D_TEST:        [579,   585,   594,   603,   612,   621,   630,   639,   645],
+//  // CONV_2D_TEST:        [633,   639,   648,   657,   666,   675,   684,   693,   699]]
+//  // clang-format on
+//
+//  f.print(llvm::outs());
+//  testFun.print(llvm::outs());
+//
+//  f.erase();
+//  testFun.erase();
+//}
 
-  auto f32Type = FloatType::getF32(&globalContext());
-
-  auto f = makeFunction("mm", {},
-                        {MemRefType::get({M, N}, f32Type, {}, 0),
-                         MemRefType::get({N, K}, f32Type, {}, 0),
-                         MemRefType::get({M, K}, f32Type, {}, 0)});
-
-  OpBuilder builder(f.getBody());
-  ScopedContext scope(builder, f.getLoc());
-
-  Value A = f.getArgument(0);
-  Value B = f.getArgument(1);
-  Value C = f.getArgument(2);
-
-  makeRiseProgram(A, B, C, [&](Value A, Value B) {
-    return mlir::edsc::highlevel::matrix_multiplication(M, N, K, A, B);
-  });
-  std_ret();
-
-  // clang-format off
-  // IMPERATIVE:       module {
-  // IMPERATIVE-LABEL:   func @mm(
-  // IMPERATIVE-SAME:             %[[VAL_0:.*]]: memref<32x16xf32>, %[[VAL_1:.*]]: memref<16x64xf32>, %[[VAL_2:.*]]: memref<32x64xf32>) {
-  // IMPERATIVE:           %[[VAL_3:.*]] = constant 32 : index
-  // IMPERATIVE:           %[[VAL_4:.*]] = constant 64 : index
-  // IMPERATIVE:           %[[VAL_5:.*]] = constant 0.000000e+00 : f32
-  // IMPERATIVE:           %[[VAL_6:.*]] = constant 0 : index
-  // IMPERATIVE:           %[[VAL_7:.*]] = constant 16 : index
-  // IMPERATIVE:           %[[VAL_8:.*]] = constant 1 : index
-  // IMPERATIVE:           scf.for %[[VAL_9:.*]] = %[[VAL_6]] to %[[VAL_3]] step %[[VAL_8]] {
-  // IMPERATIVE:             scf.for %[[VAL_10:.*]] = %[[VAL_6]] to %[[VAL_4]] step %[[VAL_8]] {
-  // IMPERATIVE:               store %[[VAL_5]], %[[VAL_2]]{{\[}}%[[VAL_9]], %[[VAL_10]]] : memref<32x64xf32>
-  // IMPERATIVE:               scf.for %[[VAL_11:.*]] = %[[VAL_6]] to %[[VAL_7]] step %[[VAL_8]] {
-  // IMPERATIVE:                 %[[VAL_12:.*]] = load %[[VAL_0]]{{\[}}%[[VAL_9]], %[[VAL_11]]] : memref<32x16xf32>
-  // IMPERATIVE:                 %[[VAL_13:.*]] = load %[[VAL_1]]{{\[}}%[[VAL_11]], %[[VAL_10]]] : memref<16x64xf32>
-  // IMPERATIVE:                 %[[VAL_14:.*]] = load %[[VAL_2]]{{\[}}%[[VAL_9]], %[[VAL_10]]] : memref<32x64xf32>
-  // IMPERATIVE:                 %[[VAL_15:.*]] = addf %[[VAL_12]], %[[VAL_13]] : f32
-  // IMPERATIVE:                 %[[VAL_16:.*]] = mulf %[[VAL_14]], %[[VAL_15]] : f32
-  // IMPERATIVE:                 store %[[VAL_16]], %[[VAL_2]]{{\[}}%[[VAL_9]], %[[VAL_10]]] : memref<32x64xf32>
-  // IMPERATIVE:               }
-  // IMPERATIVE:             }
-  // IMPERATIVE:           }
-  // IMPERATIVE:           return
-  // IMPERATIVE:         }
-  // clang-format on
-
-  f.print(llvm::outs());
-  f.erase();
-}
-
-TEST_FUNC(test_conv2) {
+TEST_FUNC(test_conv2_separable) {
   int64_t width = 9;
   int64_t height = 9;
-  int64_t kernelWidth = 3;
-  int64_t kernelHeight = 3;
+  int64_t kernelSize = 3;
   auto f32Type = FloatType::getF32(&globalContext());
 
-  auto f = makeFunction(
-      "conv2D", {},
-      {MemRefType::get({height, width}, f32Type, {}, 0),
-       MemRefType::get({kernelHeight, kernelWidth}, f32Type, {}, 0),
-       MemRefType::get({height, width}, f32Type, {}, 0)});
+  auto f = makeFunction("conv2DSeparable", {},
+                        {MemRefType::get({height, width}, f32Type, {}, 0),
+                         MemRefType::get({kernelSize}, f32Type, {}, 0),
+                         MemRefType::get({kernelSize}, f32Type, {}, 0),
+                         MemRefType::get({height, width}, f32Type, {}, 0)});
 
   OpBuilder builder(f.getBody());
   ScopedContext scope(builder, f.getLoc());
 
   Value A = f.getArgument(0);
-  Value kernel = f.getArgument(1);
-  Value output = f.getArgument(2);
+  Value kernelH = f.getArgument(1);
+  Value kernelV = f.getArgument(2);
+  Value output = f.getArgument(3);
 
-  makeRiseProgram(A, kernel, output, [](Value A, Value kernel){
-    return conv2D(A, kernel);
-  });
+  makeRiseProgram(A, kernelH, kernelV, output,
+                  [](Value A, Value kernelH, Value kernelV) {
+                    return conv2DSeparated(A, kernelH, kernelV, 1, 1, 1, 1);
+                  });
 
   std_ret();
 
   // generate test
-  auto testFun = makeFunction("conv2D_test", {}, {});
+  auto testFun = makeFunction("conv2DSeparable_test", {}, {});
   OpBuilder test_builder(testFun.getBody());
   ScopedContext test_scope(test_builder, testFun.getLoc());
   mlir::edsc::highlevel::generateTest(
-      2, {height, width}, {kernelHeight, kernelWidth}, {height, width}, f);
+      2, {height, width}, {kernelSize}, {kernelSize}, {height, width}, f);
   std_ret();
-  // clang-format off
-  // CONV_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [9, 9] strides = [9, 1] data =
-  // CONV_2D_TEST:       {{\[\[}}1,   2,   3,   4,   5,   6,   7,   8,   9],
-  // CONV_2D_TEST:        [10,   11,   12,   13,   14,   15,   16,   17,   18],
-  // CONV_2D_TEST:        [19,   20,   21,   22,   23,   24,   25,   26,   27],
-  // CONV_2D_TEST:        [28,   29,   30,   31,   32,   33,   34,   35,   36],
-  // CONV_2D_TEST:        [37,   38,   39,   40,   41,   42,   43,   44,   45],
-  // CONV_2D_TEST:        [46,   47,   48,   49,   50,   51,   52,   53,   54],
-  // CONV_2D_TEST:        [55,   56,   57,   58,   59,   60,   61,   62,   63],
-  // CONV_2D_TEST:        [64,   65,   66,   67,   68,   69,   70,   71,   72],
-  // CONV_2D_TEST:        [73,   74,   75,   76,   77,   78,   79,   80,   81]]
-  // CONV_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [3, 3] strides = [3, 1] data =
-  // CONV_2D_TEST:       {{\[\[}}1,   1,   1],
-  // CONV_2D_TEST:        [1,   1,   1],
-  // CONV_2D_TEST:        [1,   1,   1]]
-  // CONV_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [9, 9] strides = [9, 1] data =
-  // CONV_2D_TEST:       {{\[\[}}39,   45,   54,   63,   72,   81,   90,   99,   105],
-  // CONV_2D_TEST:        [93,   99,   108,   117,   126,   135,   144,   153,   159],
-  // CONV_2D_TEST:        [174,   180,   189,   198,   207,   216,   225,   234,   240],
-  // CONV_2D_TEST:        [255,   261,   270,   279,   288,   297,   306,   315,   321],
-  // CONV_2D_TEST:        [336,   342,   351,   360,   369,   378,   387,   396,   402],
-  // CONV_2D_TEST:        [417,   423,   432,   441,   450,   459,   468,   477,   483],
-  // CONV_2D_TEST:        [498,   504,   513,   522,   531,   540,   549,   558,   564],
-  // CONV_2D_TEST:        [579,   585,   594,   603,   612,   621,   630,   639,   645],
-  // CONV_2D_TEST:        [633,   639,   648,   657,   666,   675,   684,   693,   699]]
-  // clang-format on
 
   f.print(llvm::outs());
   testFun.print(llvm::outs());
@@ -231,6 +272,7 @@ TEST_FUNC(test_conv2) {
   f.erase();
   testFun.erase();
 }
+
 //
 // TEST_FUNC(test_conv_tf) {
 //  int64_t width = 7;
@@ -266,7 +308,7 @@ TEST_FUNC(test_conv2) {
 ////  kernelWidth, 1, 1}, {1, height-2, width-2, 1},
 ////                                      f);
 ////  std_ret();
-//  // clang-format off
+  // clang-format off
 //  // CONV_2DTF_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [9, 9] strides = [9, 1] data =
 //  // CONV_2DTF_TEST:       {{\[\[}}1,   2,   3,   4,   5,   6,   7,   8,   9],
 //  // CONV_2DTF_TEST:        [10,   11,   12,   13,   14,   15,   16,   17, 18],
@@ -291,7 +333,7 @@ TEST_FUNC(test_conv2) {
 //  // CONV_2DTF_TEST:        [498,   504,   513,   522,   531,   540,   549, 558,564],
 //  // CONV_2DTF_TEST:        [579,   585,   594,   603,   612,   621,   630, 639,645],
 //  // CONV_2DTF_TEST:        [633,   639,   648,   657,   666,   675,   684, 693,699]]
-//  // clang-format on
+  // clang-format on
 //
 //
 //  f.print(llvm::outs());
@@ -301,263 +343,263 @@ TEST_FUNC(test_conv2) {
 ////  testFun.erase();
 //}
 
-TEST_FUNC(build_lower_and_execute_2Dstencil) {
-  // A:MxN * B:NxK = C:MxK
-  int64_t x_size = 7;
-  int64_t y_size = 5;
+//TEST_FUNC(build_lower_and_execute_2Dstencil) {
+//  // A:MxN * B:NxK = C:MxK
+//  int64_t x_size = 7;
+//  int64_t y_size = 5;
+//
+//  auto f32Type = FloatType::getF32(&globalContext());
+//
+//  auto f = makeFunction("stencil2D", {},
+//                        {MemRefType::get({x_size, y_size}, f32Type, {}, 0),
+//                         MemRefType::get({x_size, y_size}, f32Type, {}, 0)});
+//
+//  OpBuilder builder(f.getBody());
+//  ScopedContext scope(builder, f.getLoc());
+//
+//  Value input = f.getArgument(0);
+//  Value output = f.getArgument(1);
+//
+//  makeRiseProgram(input, output, [&](Value input) {
+//    return mlir::edsc::highlevel::stencil2D(x_size, y_size, 5, 1, 3, 1, input);
+//  });
+//  std_ret();
+//
+//  // generate test
+//  auto testFun = makeFunction("stencil2D_test", {}, {});
+//  OpBuilder test_builder(testFun.getBody());
+//  ScopedContext test_scope(test_builder, testFun.getLoc());
+//  mlir::edsc::highlevel::generateTest(2, {x_size, y_size}, {x_size, y_size}, f);
+//  std_ret();
+//  // clang-format off
+//
+//// STENCIL_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [7, 5] strides = [5, 1] data =
+//// STENCIL_2D_TEST:       {{\[\[}}50,   60,   75,   90,   100],
+//// STENCIL_2D_TEST:        [95,   105,   120,   135,   145],
+//// STENCIL_2D_TEST:        [155,   165,   180,   195,   205],
+//// STENCIL_2D_TEST:        [230,   240,   255,   270,   280],
+//// STENCIL_2D_TEST:        [305,   315,   330,   345,   355],
+//// STENCIL_2D_TEST:        [365,   375,   390,   405,   415],
+//// STENCIL_2D_TEST:        [410,   420,   435,   450,   460]]
+//  // clang-format on
+//
+//  f.print(llvm::outs());
+//  testFun.print(llvm::outs());
+//
+//  f.erase();
+//  testFun.erase();
+//}
+//
+//TEST_FUNC(test_slide2d) {
+//  int64_t M = 7;
+//  int64_t N = 5;
+//  int slideOuter = 5;
+//  int slideInner = 3;
+//  auto f32Type = FloatType::getF32(&globalContext());
+//
+//  auto f = makeFunction("slide2D", {},
+//                        {MemRefType::get({M, N}, f32Type, {}, 0),
+//                         MemRefType::get({M - 2, N - 4, slideOuter, slideInner},
+//                                         f32Type, {}, 0)});
+//
+//  OpBuilder builder(f.getBody());
+//  ScopedContext scope(builder, f.getLoc());
+//
+//  Value input = f.getArgument(0);
+//  Value output = f.getArgument(1);
+//
+//  //  Value inn = in(input, arrayType(M, arrayType(N, scalarF32Type())));
+//
+//  makeRiseProgram(input, output, [&](Value input) {
+//    Value slizzled = slide2D(natType(slideOuter), natType(1),
+//                             natType(slideInner), natType(1), input);
+//
+//    return mapSeq2D(
+//        array2DType(slideOuter, slideInner, scalarF32Type()),
+//        [&](Value arr2D) {
+//          return mapSeq2D(
+//              scalarF32Type(),
+//              [&](Value elem) {
+//                return embed1(scalarF32Type(), elem, [&](Value elem) {
+//                  Value cst = std_constant_float(llvm::APFloat(0.0f), f32Type);
+//                  return elem + cst;
+//                });
+//              },
+//              arr2D);
+//        },
+//        slizzled);
+//  });
+//
+//  //  out(output, mapped);
+//
+//  std_ret();
+//
+//  // generate test
+//  auto testFun = makeFunction("slide2D_test", {}, {});
+//  OpBuilder test_builder(testFun.getBody());
+//  ScopedContext test_scope(test_builder, testFun.getLoc());
+//  mlir::edsc::highlevel::generateTest(
+//      2, {M, N}, {M - 2, N - 4, slideOuter, slideInner}, f);
+//  std_ret();
+//
+//  testFun.print(llvm::outs());
+//  f.print(llvm::outs());
+//
+//  testFun.erase();
+//  f.erase();
+//}
+//
+//TEST_FUNC(test_pad2d) {
+//  int64_t width = 5;
+//  int64_t height = 7;
+//  int padInnerl = 1;
+//  int padInnerr = 1;
+//  int padOuterl = 2;
+//  int padOuterr = 2;
+//  int64_t outWidth = padInnerl + width + padInnerr;
+//  int64_t outHeight = padOuterl + height + padOuterr;
+//
+//  auto f32Type = FloatType::getF32(&globalContext());
+//
+//  auto f =
+//      makeFunction("pad2D", {},
+//                   {MemRefType::get({height, width}, f32Type, {}, 0),
+//                    MemRefType::get({outHeight, outWidth}, f32Type, {}, 0)});
+//
+//  OpBuilder builder(f.getBody());
+//  ScopedContext scope(builder, f.getLoc());
+//
+//  Value input = f.getArgument(0);
+//  Value output = f.getArgument(1);
+//
+//  //  Value inn = in(input, arrayType(height, arrayType(width,
+//  //  scalarF32Type())));
+//
+//  makeRiseProgram(input, output, [&](Value input) {
+//    Value padded = pad2D(natType(padOuterl), natType(padOuterr),
+//                         natType(padInnerl), natType(padInnerr), input);
+//
+//    ArrayType paddedType = padded.getType().dyn_cast<ArrayType>();
+//    ArrayType innerType = paddedType.getElementType().dyn_cast<ArrayType>();
+//
+//    return mapSeq2D(
+//        scalarF32Type(),
+//        [&](Value elem) {
+//          return embed1(scalarF32Type(), elem, [&](Value elem) {
+//            Value cst = std_constant_float(llvm::APFloat(0.0f), f32Type);
+//            return elem + cst;
+//          });
+//        },
+//        padded);
+//  });
+//
+//  //  out(output, mapped);
+//
+//  std_ret();
+//
+//  // generate test
+//  auto testFun = makeFunction("pad2D_test", {}, {});
+//  OpBuilder test_builder(testFun.getBody());
+//  ScopedContext test_scope(test_builder, testFun.getLoc());
+//  mlir::edsc::highlevel::generateTest(2, {height, width}, {outHeight, outWidth},
+//                                      f);
+//  std_ret();
+//  // clang-format off
+//  // PAD_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [7, 5] strides = [5, 1] data =
+//  // PAD_2D_TEST:       {{\[\[}}0,   1,   2,   3,   4],
+//  // PAD_2D_TEST:        [5,   6,   7,   8,   9],
+//  // PAD_2D_TEST:        [10,   11,   12,   13,   14],
+//  // PAD_2D_TEST:        [15,   16,   17,   18,   19],
+//  // PAD_2D_TEST:        [20,   21,   22,   23,   24],
+//  // PAD_2D_TEST:        [25,   26,   27,   28,   29],
+//  // PAD_2D_TEST:        [30,   31,   32,   33,   34]]
+//  // PAD_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [11, 7] strides = [7, 1] data =
+//  // PAD_2D_TEST:       {{\[\[}}0,   0,   1,   2,   3,   4,   4],
+//  // PAD_2D_TEST:        [0,   0,   1,   2,   3,   4,   4],
+//  // PAD_2D_TEST:        [0,   0,   1,   2,   3,   4,   4],
+//  // PAD_2D_TEST:        [5,   5,   6,   7,   8,   9,   9],
+//  // PAD_2D_TEST:        [10,   10,   11,   12,   13,   14,   14],
+//  // PAD_2D_TEST:        [15,   15,   16,   17,   18,   19,   19],
+//  // PAD_2D_TEST:        [20,   20,   21,   22,   23,   24,   24],
+//  // PAD_2D_TEST:        [25,   25,   26,   27,   28,   29,   29],
+//  // PAD_2D_TEST:        [30,   30,   31,   32,   33,   34,   34],
+//  // PAD_2D_TEST:        [30,   30,   31,   32,   33,   34,   34],
+//  // PAD_2D_TEST:        [30,   30,   31,   32,   33,   34,   34]]
+//  // clang-format on
+//
+//  f.print(llvm::outs());
+//  testFun.print(llvm::outs());
+//
+//  f.erase();
+//  testFun.erase();
+//}
+//
+//TEST_FUNC(test_zip2D) {
+//  int64_t width = 3;
+//  int64_t height = 3;
+//  auto f32Type = FloatType::getF32(&globalContext());
+//
+//  auto f = makeFunction("zip2D", {},
+//                        {MemRefType::get({height, width}, f32Type, {}, 0),
+//                         MemRefType::get({height, width}, f32Type, {}, 0),
+//                         MemRefType::get({height, width}, f32Type, {}, 0)});
+//
+//  OpBuilder builder(f.getBody());
+//  ScopedContext scope(builder, f.getLoc());
+//
+//  Value inputA = f.getArgument(0);
+//  Value inputB = f.getArgument(1);
+//  Value output = f.getArgument(2);
+//
+//  //  Value inA = in(inputA, arrayType(height, arrayType(width,
+//  //  scalarF32Type()))); Value inB = in(inputA, arrayType(height,
+//  //  arrayType(width, scalarF32Type())));
+//
+//  makeRiseProgram(inputA, inputB, output, [&](Value inA, Value inB) {
+//    Value zipped = zip2D(inA, inB);
+//    return mapSeq2D(
+//        scalarF32Type(),
+//        [&](Value tuple) {
+//          return embed2(scalarF32Type(), ValueRange{fst(tuple), snd(tuple)},
+//                        [&](Value fst, Value snd) { return fst + snd; });
+//        },
+//        zipped);
+//  });
+//
+//  //  out(output, result);
+//  std_ret();
+//
+//  // generate test
+//  auto testFun = makeFunction("zip2D_test", {}, {});
+//  OpBuilder test_builder(testFun.getBody());
+//  ScopedContext test_scope(test_builder, testFun.getLoc());
+//  mlir::edsc::highlevel::generateTest(2, {height, width}, {height, width},
+//                                      {height, width}, f);
+//  std_ret();
+//
+//  // clang-format off
+//  // ZIP_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [3, 3] strides = [3, 1] data =
+//  // ZIP_2D_TEST:       {{\[\[}}1,   2,   3],
+//  // ZIP_2D_TEST:        [4,   5,   6],
+//  // ZIP_2D_TEST:        [7,   8,   9]]
+//  // ZIP_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [3, 3] strides = [3, 1] data =
+//  // ZIP_2D_TEST:       {{\[\[}}1,   1,   1],
+//  // ZIP_2D_TEST:        [1,   1,   1],
+//  // ZIP_2D_TEST:        [1,   1,   1]]
+//  // ZIP_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [3, 3] strides = [3, 1] data =
+//  // ZIP_2D_TEST:       {{\[\[}}2,   3,   4],
+//  // ZIP_2D_TEST:        [5,   6,   7],
+//  // ZIP_2D_TEST:        [8,   9,   10]]
+//  // clang-format on
+//
+//  f.print(llvm::outs());
+//  testFun.print(llvm::outs());
+//
+//  f.erase();
+//  testFun.erase();
+//}
 
-  auto f32Type = FloatType::getF32(&globalContext());
-
-  auto f = makeFunction("stencil2D", {},
-                        {MemRefType::get({x_size, y_size}, f32Type, {}, 0),
-                         MemRefType::get({x_size, y_size}, f32Type, {}, 0)});
-
-  OpBuilder builder(f.getBody());
-  ScopedContext scope(builder, f.getLoc());
-
-  Value input = f.getArgument(0);
-  Value output = f.getArgument(1);
-
-  makeRiseProgram(input, output, [&](Value input) {
-    return mlir::edsc::highlevel::stencil2D(x_size, y_size, 5, 1, 3, 1, input);
-  });
-  std_ret();
-
-  // generate test
-  auto testFun = makeFunction("stencil2D_test", {}, {});
-  OpBuilder test_builder(testFun.getBody());
-  ScopedContext test_scope(test_builder, testFun.getLoc());
-  mlir::edsc::highlevel::generateTest(2, {x_size, y_size}, {x_size, y_size}, f);
-  std_ret();
-  // clang-format off
-
-// STENCIL_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [7, 5] strides = [5, 1] data =
-// STENCIL_2D_TEST:       {{\[\[}}50,   60,   75,   90,   100],
-// STENCIL_2D_TEST:        [95,   105,   120,   135,   145],
-// STENCIL_2D_TEST:        [155,   165,   180,   195,   205],
-// STENCIL_2D_TEST:        [230,   240,   255,   270,   280],
-// STENCIL_2D_TEST:        [305,   315,   330,   345,   355],
-// STENCIL_2D_TEST:        [365,   375,   390,   405,   415],
-// STENCIL_2D_TEST:        [410,   420,   435,   450,   460]]
-  // clang-format on
-
-  f.print(llvm::outs());
-  testFun.print(llvm::outs());
-
-  f.erase();
-  testFun.erase();
-}
-
-TEST_FUNC(test_slide2d) {
-  int64_t M = 7;
-  int64_t N = 5;
-  int slideOuter = 5;
-  int slideInner = 3;
-  auto f32Type = FloatType::getF32(&globalContext());
-
-  auto f = makeFunction("slide2D", {},
-                        {MemRefType::get({M, N}, f32Type, {}, 0),
-                         MemRefType::get({M - 2, N - 4, slideOuter, slideInner},
-                                         f32Type, {}, 0)});
-
-  OpBuilder builder(f.getBody());
-  ScopedContext scope(builder, f.getLoc());
-
-  Value input = f.getArgument(0);
-  Value output = f.getArgument(1);
-
-  //  Value inn = in(input, arrayType(M, arrayType(N, scalarF32Type())));
-
-  makeRiseProgram(input, output, [&](Value input) {
-    Value slizzled = slide2D(natType(slideOuter), natType(1),
-                             natType(slideInner), natType(1), input);
-
-    return mapSeq2D(
-        array2DType(slideOuter, slideInner, scalarF32Type()),
-        [&](Value arr2D) {
-          return mapSeq2D(
-              scalarF32Type(),
-              [&](Value elem) {
-                return embed1(scalarF32Type(), elem, [&](Value elem) {
-                  Value cst = std_constant_float(llvm::APFloat(0.0f), f32Type);
-                  return elem + cst;
-                });
-              },
-              arr2D);
-        },
-        slizzled);
-  });
-
-  //  out(output, mapped);
-
-  std_ret();
-
-  // generate test
-  auto testFun = makeFunction("slide2D_test", {}, {});
-  OpBuilder test_builder(testFun.getBody());
-  ScopedContext test_scope(test_builder, testFun.getLoc());
-  mlir::edsc::highlevel::generateTest(
-      2, {M, N}, {M - 2, N - 4, slideOuter, slideInner}, f);
-  std_ret();
-
-  testFun.print(llvm::outs());
-  f.print(llvm::outs());
-
-  testFun.erase();
-  f.erase();
-}
-
-TEST_FUNC(test_pad2d) {
-  int64_t width = 5;
-  int64_t height = 7;
-  int padInnerl = 1;
-  int padInnerr = 1;
-  int padOuterl = 2;
-  int padOuterr = 2;
-  int64_t outWidth = padInnerl + width + padInnerr;
-  int64_t outHeight = padOuterl + height + padOuterr;
-
-  auto f32Type = FloatType::getF32(&globalContext());
-
-  auto f =
-      makeFunction("pad2D", {},
-                   {MemRefType::get({height, width}, f32Type, {}, 0),
-                    MemRefType::get({outHeight, outWidth}, f32Type, {}, 0)});
-
-  OpBuilder builder(f.getBody());
-  ScopedContext scope(builder, f.getLoc());
-
-  Value input = f.getArgument(0);
-  Value output = f.getArgument(1);
-
-  //  Value inn = in(input, arrayType(height, arrayType(width,
-  //  scalarF32Type())));
-
-  makeRiseProgram(input, output, [&](Value input) {
-    Value padded = pad2D(natType(padOuterl), natType(padOuterr),
-                         natType(padInnerl), natType(padInnerr), input);
-
-    ArrayType paddedType = padded.getType().dyn_cast<ArrayType>();
-    ArrayType innerType = paddedType.getElementType().dyn_cast<ArrayType>();
-
-    return mapSeq2D(
-        scalarF32Type(),
-        [&](Value elem) {
-          return embed1(scalarF32Type(), elem, [&](Value elem) {
-            Value cst = std_constant_float(llvm::APFloat(0.0f), f32Type);
-            return elem + cst;
-          });
-        },
-        padded);
-  });
-
-  //  out(output, mapped);
-
-  std_ret();
-
-  // generate test
-  auto testFun = makeFunction("pad2D_test", {}, {});
-  OpBuilder test_builder(testFun.getBody());
-  ScopedContext test_scope(test_builder, testFun.getLoc());
-  mlir::edsc::highlevel::generateTest(2, {height, width}, {outHeight, outWidth},
-                                      f);
-  std_ret();
-  // clang-format off
-  // PAD_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [7, 5] strides = [5, 1] data =
-  // PAD_2D_TEST:       {{\[\[}}0,   1,   2,   3,   4],
-  // PAD_2D_TEST:        [5,   6,   7,   8,   9],
-  // PAD_2D_TEST:        [10,   11,   12,   13,   14],
-  // PAD_2D_TEST:        [15,   16,   17,   18,   19],
-  // PAD_2D_TEST:        [20,   21,   22,   23,   24],
-  // PAD_2D_TEST:        [25,   26,   27,   28,   29],
-  // PAD_2D_TEST:        [30,   31,   32,   33,   34]]
-  // PAD_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [11, 7] strides = [7, 1] data =
-  // PAD_2D_TEST:       {{\[\[}}0,   0,   1,   2,   3,   4,   4],
-  // PAD_2D_TEST:        [0,   0,   1,   2,   3,   4,   4],
-  // PAD_2D_TEST:        [0,   0,   1,   2,   3,   4,   4],
-  // PAD_2D_TEST:        [5,   5,   6,   7,   8,   9,   9],
-  // PAD_2D_TEST:        [10,   10,   11,   12,   13,   14,   14],
-  // PAD_2D_TEST:        [15,   15,   16,   17,   18,   19,   19],
-  // PAD_2D_TEST:        [20,   20,   21,   22,   23,   24,   24],
-  // PAD_2D_TEST:        [25,   25,   26,   27,   28,   29,   29],
-  // PAD_2D_TEST:        [30,   30,   31,   32,   33,   34,   34],
-  // PAD_2D_TEST:        [30,   30,   31,   32,   33,   34,   34],
-  // PAD_2D_TEST:        [30,   30,   31,   32,   33,   34,   34]]
-  // clang-format on
-
-  f.print(llvm::outs());
-  testFun.print(llvm::outs());
-
-  f.erase();
-  testFun.erase();
-}
-
-TEST_FUNC(test_zip2D) {
-  int64_t width = 3;
-  int64_t height = 3;
-  auto f32Type = FloatType::getF32(&globalContext());
-
-  auto f = makeFunction("zip2D", {},
-                        {MemRefType::get({height, width}, f32Type, {}, 0),
-                         MemRefType::get({height, width}, f32Type, {}, 0),
-                         MemRefType::get({height, width}, f32Type, {}, 0)});
-
-  OpBuilder builder(f.getBody());
-  ScopedContext scope(builder, f.getLoc());
-
-  Value inputA = f.getArgument(0);
-  Value inputB = f.getArgument(1);
-  Value output = f.getArgument(2);
-
-  //  Value inA = in(inputA, arrayType(height, arrayType(width,
-  //  scalarF32Type()))); Value inB = in(inputA, arrayType(height,
-  //  arrayType(width, scalarF32Type())));
-
-  makeRiseProgram(inputA, inputB, output, [&](Value inA, Value inB) {
-    Value zipped = zip2D(inA, inB);
-    return mapSeq2D(
-        scalarF32Type(),
-        [&](Value tuple) {
-          return embed2(scalarF32Type(), ValueRange{fst(tuple), snd(tuple)},
-                        [&](Value fst, Value snd) { return fst + snd; });
-        },
-        zipped);
-  });
-
-  //  out(output, result);
-  std_ret();
-
-  // generate test
-  auto testFun = makeFunction("zip2D_test", {}, {});
-  OpBuilder test_builder(testFun.getBody());
-  ScopedContext test_scope(test_builder, testFun.getLoc());
-  mlir::edsc::highlevel::generateTest(2, {height, width}, {height, width},
-                                      {height, width}, f);
-  std_ret();
-
-  // clang-format off
-  // ZIP_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [3, 3] strides = [3, 1] data =
-  // ZIP_2D_TEST:       {{\[\[}}1,   2,   3],
-  // ZIP_2D_TEST:        [4,   5,   6],
-  // ZIP_2D_TEST:        [7,   8,   9]]
-  // ZIP_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [3, 3] strides = [3, 1] data =
-  // ZIP_2D_TEST:       {{\[\[}}1,   1,   1],
-  // ZIP_2D_TEST:        [1,   1,   1],
-  // ZIP_2D_TEST:        [1,   1,   1]]
-  // ZIP_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [3, 3] strides = [3, 1] data =
-  // ZIP_2D_TEST:       {{\[\[}}2,   3,   4],
-  // ZIP_2D_TEST:        [5,   6,   7],
-  // ZIP_2D_TEST:        [8,   9,   10]]
-  // clang-format on
-
-  f.print(llvm::outs());
-  testFun.print(llvm::outs());
-
-  f.erase();
-  testFun.erase();
-}
-
-//TEST_FUNC(test_makeRiseProgramOneArg) {
+// TEST_FUNC(test_makeRiseProgramOneArg) {
 //  auto f32Type = FloatType::getF32(&globalContext());
 //  auto f = makeFunction("makeRiseProgramOneArg", {},
 //                        {MemRefType::get({9}, f32Type, {}, 0),
@@ -580,7 +622,7 @@ TEST_FUNC(test_zip2D) {
 //  f.erase();
 //}
 //
-//TEST_FUNC(test_makeRiseProgramTwoArgs) {
+// TEST_FUNC(test_makeRiseProgramTwoArgs) {
 //  auto f32Type = FloatType::getF32(&globalContext());
 //  auto f = makeFunction("makeRiseProgramTwoArgs", {},
 //                        {MemRefType::get({9}, f32Type, {}, 0),

--- a/mlir/test/lib/Dialect/Rise/rise_highlevel_test.cpp
+++ b/mlir/test/lib/Dialect/Rise/rise_highlevel_test.cpp
@@ -136,30 +136,34 @@ TEST_FUNC(build_and_lower_matrix_multiplication) {
   std_ret();
 
   // clang-format off
-  // IMPERATIVE:       module {
-  // IMPERATIVE-LABEL:   func @mm(
-  // IMPERATIVE-SAME:             %[[VAL_0:.*]]: memref<32x16xf32>, %[[VAL_1:.*]]: memref<16x64xf32>, %[[VAL_2:.*]]: memref<32x64xf32>) {
-  // IMPERATIVE:           %[[VAL_3:.*]] = constant 32 : index
-  // IMPERATIVE:           %[[VAL_4:.*]] = constant 64 : index
-  // IMPERATIVE:           %[[VAL_5:.*]] = constant 0.000000e+00 : f32
-  // IMPERATIVE:           %[[VAL_6:.*]] = constant 0 : index
-  // IMPERATIVE:           %[[VAL_7:.*]] = constant 16 : index
-  // IMPERATIVE:           %[[VAL_8:.*]] = constant 1 : index
-  // IMPERATIVE:           scf.for %[[VAL_9:.*]] = %[[VAL_6]] to %[[VAL_3]] step %[[VAL_8]] {
-  // IMPERATIVE:             scf.for %[[VAL_10:.*]] = %[[VAL_6]] to %[[VAL_4]] step %[[VAL_8]] {
-  // IMPERATIVE:               store %[[VAL_5]], %[[VAL_2]]{{\[}}%[[VAL_9]], %[[VAL_10]]] : memref<32x64xf32>
-  // IMPERATIVE:               scf.for %[[VAL_11:.*]] = %[[VAL_6]] to %[[VAL_7]] step %[[VAL_8]] {
-  // IMPERATIVE:                 %[[VAL_12:.*]] = load %[[VAL_0]]{{\[}}%[[VAL_9]], %[[VAL_11]]] : memref<32x16xf32>
-  // IMPERATIVE:                 %[[VAL_13:.*]] = load %[[VAL_1]]{{\[}}%[[VAL_11]], %[[VAL_10]]] : memref<16x64xf32>
-  // IMPERATIVE:                 %[[VAL_14:.*]] = load %[[VAL_2]]{{\[}}%[[VAL_9]], %[[VAL_10]]] : memref<32x64xf32>
-  // IMPERATIVE:                 %[[VAL_15:.*]] = addf %[[VAL_12]], %[[VAL_13]] : f32
-  // IMPERATIVE:                 %[[VAL_16:.*]] = mulf %[[VAL_14]], %[[VAL_15]] : f32
-  // IMPERATIVE:                 store %[[VAL_16]], %[[VAL_2]]{{\[}}%[[VAL_9]], %[[VAL_10]]] : memref<32x64xf32>
-  // IMPERATIVE:               }
-  // IMPERATIVE:             }
-  // IMPERATIVE:           }
-  // IMPERATIVE:           return
-  // IMPERATIVE:         }
+// IMPERATIVE-LABEL:   func @mm(
+// IMPERATIVE-SAME:             %[[VAL_0:.*]]: memref<32x16xf32>,
+// IMPERATIVE-SAME:             %[[VAL_1:.*]]: memref<16x64xf32>,
+// IMPERATIVE-SAME:             %[[VAL_2:.*]]: memref<32x64xf32>) {
+// IMPERATIVE:           %[[VAL_3:.*]] = constant 32 : index
+// IMPERATIVE:           %[[VAL_4:.*]] = constant 64 : index
+// IMPERATIVE:           %[[VAL_5:.*]] = constant 0.000000e+00 : f32
+// IMPERATIVE:           %[[VAL_6:.*]] = constant 0 : index
+// IMPERATIVE:           %[[VAL_7:.*]] = constant 16 : index
+// IMPERATIVE:           %[[VAL_8:.*]] = constant 1 : index
+// IMPERATIVE:           scf.for %[[VAL_9:.*]] = %[[VAL_6]] to %[[VAL_3]] step %[[VAL_8]] {
+// IMPERATIVE:             scf.for %[[VAL_10:.*]] = %[[VAL_6]] to %[[VAL_4]] step %[[VAL_8]] {
+// IMPERATIVE:               %[[VAL_11:.*]] = alloc() : memref<f32>
+// IMPERATIVE:               store %[[VAL_5]], %[[VAL_11]][] : memref<f32>
+// IMPERATIVE:               scf.for %[[VAL_12:.*]] = %[[VAL_6]] to %[[VAL_7]] step %[[VAL_8]] {
+// IMPERATIVE:                 %[[VAL_13:.*]] = load %[[VAL_0]]{{\[}}%[[VAL_9]], %[[VAL_12]]] : memref<32x16xf32>
+// IMPERATIVE:                 %[[VAL_14:.*]] = load %[[VAL_1]]{{\[}}%[[VAL_12]], %[[VAL_10]]] : memref<16x64xf32>
+// IMPERATIVE:                 %[[VAL_15:.*]] = load %[[VAL_11]][] : memref<f32>
+// IMPERATIVE:                 %[[VAL_16:.*]] = addf %[[VAL_13]], %[[VAL_14]] : f32
+// IMPERATIVE:                 %[[VAL_17:.*]] = mulf %[[VAL_15]], %[[VAL_16]] : f32
+// IMPERATIVE:                 store %[[VAL_17]], %[[VAL_11]][] : memref<f32>
+// IMPERATIVE:               }
+// IMPERATIVE:               %[[VAL_18:.*]] = load %[[VAL_11]][] : memref<f32>
+// IMPERATIVE:               store %[[VAL_18]], %[[VAL_2]]{{\[}}%[[VAL_9]], %[[VAL_10]]] : memref<32x64xf32>
+// IMPERATIVE:             }
+// IMPERATIVE:           }
+// IMPERATIVE:           return
+// IMPERATIVE:         }
   // clang-format on
 
   f.print(llvm::outs());
@@ -198,8 +202,8 @@ TEST_FUNC(test_conv2) {
   makeRiseTest(f, {height, width}, getFilledMemRef({height, width}),
                getFilledMemRef({kernelHeight, kernelWidth}, 1.0f));
 
-//  mlir::edsc::highlevel::generateTest(
-//      2, {height, width}, {kernelHeight, kernelWidth}, {height, width}, f);
+  //  mlir::edsc::highlevel::generateTest(
+  //      2, {height, width}, {kernelHeight, kernelWidth}, {height, width}, f);
   std_ret();
   // clang-format off
   // CONV_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [9, 9] strides = [9, 1] data =
@@ -309,7 +313,8 @@ TEST_FUNC(test_conv2_separable) {
 //  auto testFun = makeFunction("conv2DTF_test", {}, {});
 //  OpBuilder test_builder(testFun.getBody());
 //  ScopedContext test_scope(test_builder, testFun.getLoc());
-//  makeRiseTest(f, {1, height-2, width-2, 1}, getFilledMemRef({1, height, width, 1}), getFilledMemRef({kernelHeight, kernelWidth, 1, 1}, 1.0f));
+//  makeRiseTest(f, {1, height-2, width-2, 1}, getFilledMemRef({1, height,
+//  width, 1}), getFilledMemRef({kernelHeight, kernelWidth, 1, 1}, 1.0f));
 //
 //  std_ret();
 // clang-format off

--- a/mlir/test/lib/Dialect/Rise/rise_highlevel_test.cpp
+++ b/mlir/test/lib/Dialect/Rise/rise_highlevel_test.cpp
@@ -70,6 +70,7 @@ using namespace mlir::edsc::op;
 using namespace mlir::edsc::type;
 using namespace mlir::edsc::highlevel;
 using namespace mlir::edsc::abstraction;
+using namespace mlir::edsc::utils;
 
 static FuncOp makeFunction(StringRef name, ArrayRef<Type> results = {},
                            ArrayRef<Type> args = {}) {
@@ -109,127 +110,130 @@ TEST_FUNC(declare_functions) {
   printBinOp.erase();
 }
 
-//TEST_FUNC(build_and_lower_matrix_multiplication) {
-//  // A:MxN * B:NxK = C:MxK
-//  int64_t M = 32;
-//  int64_t N = 16;
-//  int64_t K = 64;
-//
-//  auto f32Type = FloatType::getF32(&globalContext());
-//
-//  auto f = makeFunction("mm", {},
-//                        {MemRefType::get({M, N}, f32Type, {}, 0),
-//                         MemRefType::get({N, K}, f32Type, {}, 0),
-//                         MemRefType::get({M, K}, f32Type, {}, 0)});
-//
-//  OpBuilder builder(f.getBody());
-//  ScopedContext scope(builder, f.getLoc());
-//
-//  Value A = f.getArgument(0);
-//  Value B = f.getArgument(1);
-//  Value C = f.getArgument(2);
-//
-//  makeRiseProgram(A, B, C, [&](Value A, Value B) {
-//    return mlir::edsc::highlevel::matrix_multiplication(M, N, K, A, B);
-//  });
-//  std_ret();
-//
-//  // clang-format off
-//  // IMPERATIVE:       module {
-//  // IMPERATIVE-LABEL:   func @mm(
-//  // IMPERATIVE-SAME:             %[[VAL_0:.*]]: memref<32x16xf32>, %[[VAL_1:.*]]: memref<16x64xf32>, %[[VAL_2:.*]]: memref<32x64xf32>) {
-//  // IMPERATIVE:           %[[VAL_3:.*]] = constant 32 : index
-//  // IMPERATIVE:           %[[VAL_4:.*]] = constant 64 : index
-//  // IMPERATIVE:           %[[VAL_5:.*]] = constant 0.000000e+00 : f32
-//  // IMPERATIVE:           %[[VAL_6:.*]] = constant 0 : index
-//  // IMPERATIVE:           %[[VAL_7:.*]] = constant 16 : index
-//  // IMPERATIVE:           %[[VAL_8:.*]] = constant 1 : index
-//  // IMPERATIVE:           scf.for %[[VAL_9:.*]] = %[[VAL_6]] to %[[VAL_3]] step %[[VAL_8]] {
-//  // IMPERATIVE:             scf.for %[[VAL_10:.*]] = %[[VAL_6]] to %[[VAL_4]] step %[[VAL_8]] {
-//  // IMPERATIVE:               store %[[VAL_5]], %[[VAL_2]]{{\[}}%[[VAL_9]], %[[VAL_10]]] : memref<32x64xf32>
-//  // IMPERATIVE:               scf.for %[[VAL_11:.*]] = %[[VAL_6]] to %[[VAL_7]] step %[[VAL_8]] {
-//  // IMPERATIVE:                 %[[VAL_12:.*]] = load %[[VAL_0]]{{\[}}%[[VAL_9]], %[[VAL_11]]] : memref<32x16xf32>
-//  // IMPERATIVE:                 %[[VAL_13:.*]] = load %[[VAL_1]]{{\[}}%[[VAL_11]], %[[VAL_10]]] : memref<16x64xf32>
-//  // IMPERATIVE:                 %[[VAL_14:.*]] = load %[[VAL_2]]{{\[}}%[[VAL_9]], %[[VAL_10]]] : memref<32x64xf32>
-//  // IMPERATIVE:                 %[[VAL_15:.*]] = addf %[[VAL_12]], %[[VAL_13]] : f32
-//  // IMPERATIVE:                 %[[VAL_16:.*]] = mulf %[[VAL_14]], %[[VAL_15]] : f32
-//  // IMPERATIVE:                 store %[[VAL_16]], %[[VAL_2]]{{\[}}%[[VAL_9]], %[[VAL_10]]] : memref<32x64xf32>
-//  // IMPERATIVE:               }
-//  // IMPERATIVE:             }
-//  // IMPERATIVE:           }
-//  // IMPERATIVE:           return
-//  // IMPERATIVE:         }
-//  // clang-format on
-//
-//  f.print(llvm::outs());
-//  f.erase();
-//}
-//
-//TEST_FUNC(test_conv2) {
-//  int64_t width = 9;
-//  int64_t height = 9;
-//  int64_t kernelWidth = 3;
-//  int64_t kernelHeight = 3;
-//  auto f32Type = FloatType::getF32(&globalContext());
-//
-//  auto f = makeFunction(
-//      "conv2D", {},
-//      {MemRefType::get({height, width}, f32Type, {}, 0),
-//       MemRefType::get({kernelHeight, kernelWidth}, f32Type, {}, 0),
-//       MemRefType::get({height, width}, f32Type, {}, 0)});
-//
-//  OpBuilder builder(f.getBody());
-//  ScopedContext scope(builder, f.getLoc());
-//
-//  Value A = f.getArgument(0);
-//  Value kernel = f.getArgument(1);
-//  Value output = f.getArgument(2);
-//
-//  makeRiseProgram(A, kernel, output,
-//                  [](Value A, Value kernel) { return conv2D(A, kernel); });
-//
-//  std_ret();
-//
-//  // generate test
-//  auto testFun = makeFunction("conv2D_test", {}, {});
-//  OpBuilder test_builder(testFun.getBody());
-//  ScopedContext test_scope(test_builder, testFun.getLoc());
+TEST_FUNC(build_and_lower_matrix_multiplication) {
+  // A:MxN * B:NxK = C:MxK
+  int64_t M = 32;
+  int64_t N = 16;
+  int64_t K = 64;
+
+  auto f32Type = FloatType::getF32(&globalContext());
+
+  auto f = makeFunction("mm", {},
+                        {MemRefType::get({M, N}, f32Type, {}, 0),
+                         MemRefType::get({N, K}, f32Type, {}, 0),
+                         MemRefType::get({M, K}, f32Type, {}, 0)});
+
+  OpBuilder builder(f.getBody());
+  ScopedContext scope(builder, f.getLoc());
+
+  Value A = f.getArgument(0);
+  Value B = f.getArgument(1);
+  Value C = f.getArgument(2);
+
+  makeRiseProgram(C, A, B)([&](Value A, Value B) {
+    return mlir::edsc::highlevel::matrix_multiplication(M, N, K, A, B);
+  });
+  std_ret();
+
+  // clang-format off
+  // IMPERATIVE:       module {
+  // IMPERATIVE-LABEL:   func @mm(
+  // IMPERATIVE-SAME:             %[[VAL_0:.*]]: memref<32x16xf32>, %[[VAL_1:.*]]: memref<16x64xf32>, %[[VAL_2:.*]]: memref<32x64xf32>) {
+  // IMPERATIVE:           %[[VAL_3:.*]] = constant 32 : index
+  // IMPERATIVE:           %[[VAL_4:.*]] = constant 64 : index
+  // IMPERATIVE:           %[[VAL_5:.*]] = constant 0.000000e+00 : f32
+  // IMPERATIVE:           %[[VAL_6:.*]] = constant 0 : index
+  // IMPERATIVE:           %[[VAL_7:.*]] = constant 16 : index
+  // IMPERATIVE:           %[[VAL_8:.*]] = constant 1 : index
+  // IMPERATIVE:           scf.for %[[VAL_9:.*]] = %[[VAL_6]] to %[[VAL_3]] step %[[VAL_8]] {
+  // IMPERATIVE:             scf.for %[[VAL_10:.*]] = %[[VAL_6]] to %[[VAL_4]] step %[[VAL_8]] {
+  // IMPERATIVE:               store %[[VAL_5]], %[[VAL_2]]{{\[}}%[[VAL_9]], %[[VAL_10]]] : memref<32x64xf32>
+  // IMPERATIVE:               scf.for %[[VAL_11:.*]] = %[[VAL_6]] to %[[VAL_7]] step %[[VAL_8]] {
+  // IMPERATIVE:                 %[[VAL_12:.*]] = load %[[VAL_0]]{{\[}}%[[VAL_9]], %[[VAL_11]]] : memref<32x16xf32>
+  // IMPERATIVE:                 %[[VAL_13:.*]] = load %[[VAL_1]]{{\[}}%[[VAL_11]], %[[VAL_10]]] : memref<16x64xf32>
+  // IMPERATIVE:                 %[[VAL_14:.*]] = load %[[VAL_2]]{{\[}}%[[VAL_9]], %[[VAL_10]]] : memref<32x64xf32>
+  // IMPERATIVE:                 %[[VAL_15:.*]] = addf %[[VAL_12]], %[[VAL_13]] : f32
+  // IMPERATIVE:                 %[[VAL_16:.*]] = mulf %[[VAL_14]], %[[VAL_15]] : f32
+  // IMPERATIVE:                 store %[[VAL_16]], %[[VAL_2]]{{\[}}%[[VAL_9]], %[[VAL_10]]] : memref<32x64xf32>
+  // IMPERATIVE:               }
+  // IMPERATIVE:             }
+  // IMPERATIVE:           }
+  // IMPERATIVE:           return
+  // IMPERATIVE:         }
+  // clang-format on
+
+  f.print(llvm::outs());
+  f.erase();
+}
+
+TEST_FUNC(test_conv2) {
+  int64_t width = 9;
+  int64_t height = 9;
+  int64_t kernelWidth = 3;
+  int64_t kernelHeight = 3;
+  auto f32Type = FloatType::getF32(&globalContext());
+
+  auto f = makeFunction(
+      "conv2D", {},
+      {MemRefType::get({height, width}, f32Type, {}, 0),
+       MemRefType::get({kernelHeight, kernelWidth}, f32Type, {}, 0),
+       MemRefType::get({height, width}, f32Type, {}, 0)});
+
+  OpBuilder builder(f.getBody());
+  ScopedContext scope(builder, f.getLoc());
+
+  Value A = f.getArgument(0);
+  Value kernel = f.getArgument(1);
+  Value output = f.getArgument(2);
+
+  makeRiseProgram(output, A, kernel)(
+      [](Value A, Value kernel) { return conv2D(A, kernel); });
+
+  std_ret();
+
+  // generate test
+  auto testFun = makeFunction("conv2D_test", {}, {});
+  OpBuilder test_builder(testFun.getBody());
+  ScopedContext test_scope(test_builder, testFun.getLoc());
+  makeRiseTest(f, {height, width}, getFilledMemRef({height, width}),
+               getFilledMemRef({kernelHeight, kernelWidth}, 1.0f));
+
 //  mlir::edsc::highlevel::generateTest(
 //      2, {height, width}, {kernelHeight, kernelWidth}, {height, width}, f);
-//  std_ret();
-//  // clang-format off
-//  // CONV_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [9, 9] strides = [9, 1] data =
-//  // CONV_2D_TEST:       {{\[\[}}1,   2,   3,   4,   5,   6,   7,   8,   9],
-//  // CONV_2D_TEST:        [10,   11,   12,   13,   14,   15,   16,   17,   18],
-//  // CONV_2D_TEST:        [19,   20,   21,   22,   23,   24,   25,   26,   27],
-//  // CONV_2D_TEST:        [28,   29,   30,   31,   32,   33,   34,   35,   36],
-//  // CONV_2D_TEST:        [37,   38,   39,   40,   41,   42,   43,   44,   45],
-//  // CONV_2D_TEST:        [46,   47,   48,   49,   50,   51,   52,   53,   54],
-//  // CONV_2D_TEST:        [55,   56,   57,   58,   59,   60,   61,   62,   63],
-//  // CONV_2D_TEST:        [64,   65,   66,   67,   68,   69,   70,   71,   72],
-//  // CONV_2D_TEST:        [73,   74,   75,   76,   77,   78,   79,   80,   81]]
-//  // CONV_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [3, 3] strides = [3, 1] data =
-//  // CONV_2D_TEST:       {{\[\[}}1,   1,   1],
-//  // CONV_2D_TEST:        [1,   1,   1],
-//  // CONV_2D_TEST:        [1,   1,   1]]
-//  // CONV_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [9, 9] strides = [9, 1] data =
-//  // CONV_2D_TEST:       {{\[\[}}39,   45,   54,   63,   72,   81,   90,   99,   105],
-//  // CONV_2D_TEST:        [93,   99,   108,   117,   126,   135,   144,   153,   159],
-//  // CONV_2D_TEST:        [174,   180,   189,   198,   207,   216,   225,   234,   240],
-//  // CONV_2D_TEST:        [255,   261,   270,   279,   288,   297,   306,   315,   321],
-//  // CONV_2D_TEST:        [336,   342,   351,   360,   369,   378,   387,   396,   402],
-//  // CONV_2D_TEST:        [417,   423,   432,   441,   450,   459,   468,   477,   483],
-//  // CONV_2D_TEST:        [498,   504,   513,   522,   531,   540,   549,   558,   564],
-//  // CONV_2D_TEST:        [579,   585,   594,   603,   612,   621,   630,   639,   645],
-//  // CONV_2D_TEST:        [633,   639,   648,   657,   666,   675,   684,   693,   699]]
-//  // clang-format on
-//
-//  f.print(llvm::outs());
-//  testFun.print(llvm::outs());
-//
-//  f.erase();
-//  testFun.erase();
-//}
+  std_ret();
+  // clang-format off
+  // CONV_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [9, 9] strides = [9, 1] data =
+  // CONV_2D_TEST:       {{\[\[}}0,   1,   2,   3,   4,   5,   6,   7,   8],
+  // CONV_2D_TEST:        [9,   10,   11,   12,   13,   14,   15,   16,   17],
+  // CONV_2D_TEST:        [18,   19,   20,   21,   22,   23,   24,   25,   26],
+  // CONV_2D_TEST:        [27,   28,   29,   30,   31,   32,   33,   34,   35],
+  // CONV_2D_TEST:        [36,   37,   38,   39,   40,   41,   42,   43,   44],
+  // CONV_2D_TEST:        [45,   46,   47,   48,   49,   50,   51,   52,   53],
+  // CONV_2D_TEST:        [54,   55,   56,   57,   58,   59,   60,   61,   62],
+  // CONV_2D_TEST:        [63,   64,   65,   66,   67,   68,   69,   70,   71],
+  // CONV_2D_TEST:        [72,   73,   74,   75,   76,   77,   78,   79,   80]]
+  // CONV_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [3, 3] strides = [3, 1] data =
+  // CONV_2D_TEST:       {{\[\[}}1,   1,   1],
+  // CONV_2D_TEST:        [1,   1,   1],
+  // CONV_2D_TEST:        [1,   1,   1]]
+  // CONV_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [9, 9] strides = [9, 1] data =
+  // CONV_2D_TEST:       {{\[\[}}30,   36,   45,   54,   63,   72,   81,   90,   96],
+  // CONV_2D_TEST:        [84,   90,   99,   108,   117,   126,   135,   144,   150],
+  // CONV_2D_TEST:        [165,   171,   180,   189,   198,   207,   216,   225,   231],
+  // CONV_2D_TEST:        [246,   252,   261,   270,   279,   288,   297,   306,   312],
+  // CONV_2D_TEST:        [327,   333,   342,   351,   360,   369,   378,   387,   393],
+  // CONV_2D_TEST:        [408,   414,   423,   432,   441,   450,   459,   468,   474],
+  // CONV_2D_TEST:        [489,   495,   504,   513,   522,   531,   540,   549,   555],
+  // CONV_2D_TEST:        [570,   576,   585,   594,   603,   612,   621,   630,   636],
+  // CONV_2D_TEST:        [624,   630,   639,   648,   657,   666,   675,   684,   690]]
+  // clang-format on
+
+  f.print(llvm::outs());
+  testFun.print(llvm::outs());
+
+  f.erase();
+  testFun.erase();
+}
 
 TEST_FUNC(test_conv2_separable) {
   int64_t width = 9;
@@ -251,10 +255,10 @@ TEST_FUNC(test_conv2_separable) {
   Value kernelV = f.getArgument(2);
   Value output = f.getArgument(3);
 
-  makeRiseProgram(A, kernelH, kernelV, output,
-                  [](Value A, Value kernelH, Value kernelV) {
-                    return conv2DSeparated(A, kernelH, kernelV, 1, 1, 1, 1);
-                  });
+  makeRiseProgram(output, A, kernelH,
+                  kernelV)([](Value A, Value kernelH, Value kernelV) {
+    return conv2DSeparated(A, kernelH, kernelV, 1, 1, 1, 1);
+  });
 
   std_ret();
 
@@ -262,13 +266,14 @@ TEST_FUNC(test_conv2_separable) {
   auto testFun = makeFunction("conv2DSeparable_test", {}, {});
   OpBuilder test_builder(testFun.getBody());
   ScopedContext test_scope(test_builder, testFun.getLoc());
-  mlir::edsc::highlevel::generateTest(
-      2, {height, width}, {kernelSize}, {kernelSize}, {height, width}, f);
+
+  makeRiseTest(f, {height, width}, getFilledMemRef({height, width}),
+               getFilledMemRef({3}, 1.0f), getFilledMemRef({3}, 1.0f));
+
   std_ret();
 
   f.print(llvm::outs());
   testFun.print(llvm::outs());
-
   f.erase();
   testFun.erase();
 }
@@ -295,370 +300,304 @@ TEST_FUNC(test_conv2_separable) {
 //  Value kernel = f.getArgument(1);
 //  Value output = f.getArgument(2);
 //
-//  makeRiseProgram(input, kernel, output, [](Value input, Value kernel){
+//  makeRiseProgram(output, input, kernel)([&](Value input, Value kernel){
 //    return conv2DTF(input, kernel);
 //  });
 //  std_ret();
 //
 ////  // generate test
-////  auto testFun = makeFunction("conv2DTF_test", {}, {});
-////  OpBuilder test_builder(testFun.getBody());
-////  ScopedContext test_scope(test_builder, testFun.getLoc());
-////  mlir::edsc::highlevel::generateTest(4, {1, height, width, 1}, {kernelHeight,
-////  kernelWidth, 1, 1}, {1, height-2, width-2, 1},
-////                                      f);
-////  std_ret();
+//  auto testFun = makeFunction("conv2DTF_test", {}, {});
+//  OpBuilder test_builder(testFun.getBody());
+//  ScopedContext test_scope(test_builder, testFun.getLoc());
+//  makeRiseTest(f, {1, height-2, width-2, 1}, getFilledMemRef({1, height, width, 1}), getFilledMemRef({kernelHeight, kernelWidth, 1, 1}, 1.0f));
+//
+//  std_ret();
+// clang-format off
+  // CONV_2DTF_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [9, 9] strides = [9, 1] data =
+  // CONV_2DTF_TEST:       {{\[\[}}1,   2,   3,   4,   5,   6,   7,   8,   9],
+  // CONV_2DTF_TEST:        [10,   11,   12,   13,   14,   15,   16,   17, 18],
+  // CONV_2DTF_TEST:        [19,   20,   21,   22,   23,   24,   25,   26, 27],
+  // CONV_2DTF_TEST:        [28,   29,   30,   31,   32,   33,   34,   35, 36],
+  // CONV_2DTF_TEST:        [37,   38,   39,   40,   41,   42,   43,   44, 45],
+  // CONV_2DTF_TEST:        [46,   47,   48,   49,   50,   51,   52,   53, 54],
+  // CONV_2DTF_TEST:        [55,   56,   57,   58,   59,   60,   61,   62, 63],
+  // CONV_2DTF_TEST:        [64,   65,   66,   67,   68,   69,   70,   71, 72],
+  // CONV_2DTF_TEST:        [73,   74,   75,   76,   77,   78,   79,   80, 81]]
+  // CONV_2DTF_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [3, 3] strides = [3, 1] data =
+  // CONV_2DTF_TEST:       {{\[\[}}1,   1,   1],
+  // CONV_2DTF_TEST:        [1,   1,   1],
+  // CONV_2DTF_TEST:        [1,   1,   1]]
+  // CONV_2DTF_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [9, 9] strides = [9, 1] data =
+  // CONV_2DTF_TEST:       {{\[\[}}39,   45,   54,   63,   72,   81,   90,   99,105],
+  // CONV_2DTF_TEST:        [93,   99,   108,   117,   126,   135,   144,   153,159],
+  // CONV_2DTF_TEST:        [174,   180,   189,   198,   207,   216,   225, 234,240],
+  // CONV_2DTF_TEST:        [255,   261,   270,   279,   288,   297,   306, 315,321],
+  // CONV_2DTF_TEST:        [336,   342,   351,   360,   369,   378,   387, 396,402],
+  // CONV_2DTF_TEST:        [417,   423,   432,   441,   450,   459,   468, 477,483],
+  // CONV_2DTF_TEST:        [498,   504,   513,   522,   531,   540,   549, 558,564],
+  // CONV_2DTF_TEST:        [579,   585,   594,   603,   612,   621,   630, 639,645],
+  // CONV_2DTF_TEST:        [633,   639,   648,   657,   666,   675,   684, 693,699]]
+// clang-format on
+
+//
+//  f.print(llvm::outs());
+//  testFun.print(llvm::outs());
+//  f.erase();
+//  testFun.erase();
+//}
+
+TEST_FUNC(build_lower_and_execute_2Dstencil) {
+  // A:MxN * B:NxK = C:MxK
+  int64_t x_size = 7;
+  int64_t y_size = 5;
+
+  auto f32Type = FloatType::getF32(&globalContext());
+
+  auto f = makeFunction("stencil2D", {},
+                        {MemRefType::get({x_size, y_size}, f32Type, {}, 0),
+                         MemRefType::get({x_size, y_size}, f32Type, {}, 0)});
+
+  OpBuilder builder(f.getBody());
+  ScopedContext scope(builder, f.getLoc());
+
+  Value input = f.getArgument(0);
+  Value output = f.getArgument(1);
+
+  makeRiseProgram(output, input)([&](Value input) {
+    return mlir::edsc::highlevel::stencil2D(x_size, y_size, 5, 1, 3, 1, input);
+  });
+  std_ret();
+
+  // generate test
+  auto testFun = makeFunction("stencil2D_test", {}, {});
+  OpBuilder test_builder(testFun.getBody());
+  ScopedContext test_scope(test_builder, testFun.getLoc());
+  makeRiseTest(f, {x_size, y_size}, getFilledMemRef({x_size, y_size}));
+
+  std_ret();
   // clang-format off
-//  // CONV_2DTF_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [9, 9] strides = [9, 1] data =
-//  // CONV_2DTF_TEST:       {{\[\[}}1,   2,   3,   4,   5,   6,   7,   8,   9],
-//  // CONV_2DTF_TEST:        [10,   11,   12,   13,   14,   15,   16,   17, 18],
-//  // CONV_2DTF_TEST:        [19,   20,   21,   22,   23,   24,   25,   26, 27],
-//  // CONV_2DTF_TEST:        [28,   29,   30,   31,   32,   33,   34,   35, 36],
-//  // CONV_2DTF_TEST:        [37,   38,   39,   40,   41,   42,   43,   44, 45],
-//  // CONV_2DTF_TEST:        [46,   47,   48,   49,   50,   51,   52,   53, 54],
-//  // CONV_2DTF_TEST:        [55,   56,   57,   58,   59,   60,   61,   62, 63],
-//  // CONV_2DTF_TEST:        [64,   65,   66,   67,   68,   69,   70,   71, 72],
-//  // CONV_2DTF_TEST:        [73,   74,   75,   76,   77,   78,   79,   80, 81]]
-//  // CONV_2DTF_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [3, 3] strides = [3, 1] data =
-//  // CONV_2DTF_TEST:       {{\[\[}}1,   1,   1],
-//  // CONV_2DTF_TEST:        [1,   1,   1],
-//  // CONV_2DTF_TEST:        [1,   1,   1]]
-//  // CONV_2DTF_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [9, 9] strides = [9, 1] data =
-//  // CONV_2DTF_TEST:       {{\[\[}}39,   45,   54,   63,   72,   81,   90,   99,105],
-//  // CONV_2DTF_TEST:        [93,   99,   108,   117,   126,   135,   144,   153,159],
-//  // CONV_2DTF_TEST:        [174,   180,   189,   198,   207,   216,   225, 234,240],
-//  // CONV_2DTF_TEST:        [255,   261,   270,   279,   288,   297,   306, 315,321],
-//  // CONV_2DTF_TEST:        [336,   342,   351,   360,   369,   378,   387, 396,402],
-//  // CONV_2DTF_TEST:        [417,   423,   432,   441,   450,   459,   468, 477,483],
-//  // CONV_2DTF_TEST:        [498,   504,   513,   522,   531,   540,   549, 558,564],
-//  // CONV_2DTF_TEST:        [579,   585,   594,   603,   612,   621,   630, 639,645],
-//  // CONV_2DTF_TEST:        [633,   639,   648,   657,   666,   675,   684, 693,699]]
+
+// STENCIL_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [7, 5] strides = [5, 1] data =
+// STENCIL_2D_TEST:       {{\[\[}}50,   60,   75,   90,   100],
+// STENCIL_2D_TEST:        [95,   105,   120,   135,   145],
+// STENCIL_2D_TEST:        [155,   165,   180,   195,   205],
+// STENCIL_2D_TEST:        [230,   240,   255,   270,   280],
+// STENCIL_2D_TEST:        [305,   315,   330,   345,   355],
+// STENCIL_2D_TEST:        [365,   375,   390,   405,   415],
+// STENCIL_2D_TEST:        [410,   420,   435,   450,   460]]
   // clang-format on
-//
-//
-//  f.print(llvm::outs());
-////  testFun.print(llvm::outs());
-//
-//  f.erase();
-////  testFun.erase();
-//}
 
-//TEST_FUNC(build_lower_and_execute_2Dstencil) {
-//  // A:MxN * B:NxK = C:MxK
-//  int64_t x_size = 7;
-//  int64_t y_size = 5;
-//
-//  auto f32Type = FloatType::getF32(&globalContext());
-//
-//  auto f = makeFunction("stencil2D", {},
-//                        {MemRefType::get({x_size, y_size}, f32Type, {}, 0),
-//                         MemRefType::get({x_size, y_size}, f32Type, {}, 0)});
-//
-//  OpBuilder builder(f.getBody());
-//  ScopedContext scope(builder, f.getLoc());
-//
-//  Value input = f.getArgument(0);
-//  Value output = f.getArgument(1);
-//
-//  makeRiseProgram(input, output, [&](Value input) {
-//    return mlir::edsc::highlevel::stencil2D(x_size, y_size, 5, 1, 3, 1, input);
-//  });
-//  std_ret();
-//
-//  // generate test
-//  auto testFun = makeFunction("stencil2D_test", {}, {});
-//  OpBuilder test_builder(testFun.getBody());
-//  ScopedContext test_scope(test_builder, testFun.getLoc());
-//  mlir::edsc::highlevel::generateTest(2, {x_size, y_size}, {x_size, y_size}, f);
-//  std_ret();
-//  // clang-format off
-//
-//// STENCIL_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [7, 5] strides = [5, 1] data =
-//// STENCIL_2D_TEST:       {{\[\[}}50,   60,   75,   90,   100],
-//// STENCIL_2D_TEST:        [95,   105,   120,   135,   145],
-//// STENCIL_2D_TEST:        [155,   165,   180,   195,   205],
-//// STENCIL_2D_TEST:        [230,   240,   255,   270,   280],
-//// STENCIL_2D_TEST:        [305,   315,   330,   345,   355],
-//// STENCIL_2D_TEST:        [365,   375,   390,   405,   415],
-//// STENCIL_2D_TEST:        [410,   420,   435,   450,   460]]
-//  // clang-format on
-//
-//  f.print(llvm::outs());
-//  testFun.print(llvm::outs());
-//
-//  f.erase();
-//  testFun.erase();
-//}
-//
-//TEST_FUNC(test_slide2d) {
-//  int64_t M = 7;
-//  int64_t N = 5;
-//  int slideOuter = 5;
-//  int slideInner = 3;
-//  auto f32Type = FloatType::getF32(&globalContext());
-//
-//  auto f = makeFunction("slide2D", {},
-//                        {MemRefType::get({M, N}, f32Type, {}, 0),
-//                         MemRefType::get({M - 2, N - 4, slideOuter, slideInner},
-//                                         f32Type, {}, 0)});
-//
-//  OpBuilder builder(f.getBody());
-//  ScopedContext scope(builder, f.getLoc());
-//
-//  Value input = f.getArgument(0);
-//  Value output = f.getArgument(1);
-//
-//  //  Value inn = in(input, arrayType(M, arrayType(N, scalarF32Type())));
-//
-//  makeRiseProgram(input, output, [&](Value input) {
-//    Value slizzled = slide2D(natType(slideOuter), natType(1),
-//                             natType(slideInner), natType(1), input);
-//
-//    return mapSeq2D(
-//        array2DType(slideOuter, slideInner, scalarF32Type()),
-//        [&](Value arr2D) {
-//          return mapSeq2D(
-//              scalarF32Type(),
-//              [&](Value elem) {
-//                return embed1(scalarF32Type(), elem, [&](Value elem) {
-//                  Value cst = std_constant_float(llvm::APFloat(0.0f), f32Type);
-//                  return elem + cst;
-//                });
-//              },
-//              arr2D);
-//        },
-//        slizzled);
-//  });
-//
-//  //  out(output, mapped);
-//
-//  std_ret();
-//
-//  // generate test
-//  auto testFun = makeFunction("slide2D_test", {}, {});
-//  OpBuilder test_builder(testFun.getBody());
-//  ScopedContext test_scope(test_builder, testFun.getLoc());
-//  mlir::edsc::highlevel::generateTest(
-//      2, {M, N}, {M - 2, N - 4, slideOuter, slideInner}, f);
-//  std_ret();
-//
-//  testFun.print(llvm::outs());
-//  f.print(llvm::outs());
-//
-//  testFun.erase();
-//  f.erase();
-//}
-//
-//TEST_FUNC(test_pad2d) {
-//  int64_t width = 5;
-//  int64_t height = 7;
-//  int padInnerl = 1;
-//  int padInnerr = 1;
-//  int padOuterl = 2;
-//  int padOuterr = 2;
-//  int64_t outWidth = padInnerl + width + padInnerr;
-//  int64_t outHeight = padOuterl + height + padOuterr;
-//
-//  auto f32Type = FloatType::getF32(&globalContext());
-//
-//  auto f =
-//      makeFunction("pad2D", {},
-//                   {MemRefType::get({height, width}, f32Type, {}, 0),
-//                    MemRefType::get({outHeight, outWidth}, f32Type, {}, 0)});
-//
-//  OpBuilder builder(f.getBody());
-//  ScopedContext scope(builder, f.getLoc());
-//
-//  Value input = f.getArgument(0);
-//  Value output = f.getArgument(1);
-//
-//  //  Value inn = in(input, arrayType(height, arrayType(width,
-//  //  scalarF32Type())));
-//
-//  makeRiseProgram(input, output, [&](Value input) {
-//    Value padded = pad2D(natType(padOuterl), natType(padOuterr),
-//                         natType(padInnerl), natType(padInnerr), input);
-//
-//    ArrayType paddedType = padded.getType().dyn_cast<ArrayType>();
-//    ArrayType innerType = paddedType.getElementType().dyn_cast<ArrayType>();
-//
-//    return mapSeq2D(
-//        scalarF32Type(),
-//        [&](Value elem) {
-//          return embed1(scalarF32Type(), elem, [&](Value elem) {
-//            Value cst = std_constant_float(llvm::APFloat(0.0f), f32Type);
-//            return elem + cst;
-//          });
-//        },
-//        padded);
-//  });
-//
-//  //  out(output, mapped);
-//
-//  std_ret();
-//
-//  // generate test
-//  auto testFun = makeFunction("pad2D_test", {}, {});
-//  OpBuilder test_builder(testFun.getBody());
-//  ScopedContext test_scope(test_builder, testFun.getLoc());
-//  mlir::edsc::highlevel::generateTest(2, {height, width}, {outHeight, outWidth},
-//                                      f);
-//  std_ret();
-//  // clang-format off
-//  // PAD_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [7, 5] strides = [5, 1] data =
-//  // PAD_2D_TEST:       {{\[\[}}0,   1,   2,   3,   4],
-//  // PAD_2D_TEST:        [5,   6,   7,   8,   9],
-//  // PAD_2D_TEST:        [10,   11,   12,   13,   14],
-//  // PAD_2D_TEST:        [15,   16,   17,   18,   19],
-//  // PAD_2D_TEST:        [20,   21,   22,   23,   24],
-//  // PAD_2D_TEST:        [25,   26,   27,   28,   29],
-//  // PAD_2D_TEST:        [30,   31,   32,   33,   34]]
-//  // PAD_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [11, 7] strides = [7, 1] data =
-//  // PAD_2D_TEST:       {{\[\[}}0,   0,   1,   2,   3,   4,   4],
-//  // PAD_2D_TEST:        [0,   0,   1,   2,   3,   4,   4],
-//  // PAD_2D_TEST:        [0,   0,   1,   2,   3,   4,   4],
-//  // PAD_2D_TEST:        [5,   5,   6,   7,   8,   9,   9],
-//  // PAD_2D_TEST:        [10,   10,   11,   12,   13,   14,   14],
-//  // PAD_2D_TEST:        [15,   15,   16,   17,   18,   19,   19],
-//  // PAD_2D_TEST:        [20,   20,   21,   22,   23,   24,   24],
-//  // PAD_2D_TEST:        [25,   25,   26,   27,   28,   29,   29],
-//  // PAD_2D_TEST:        [30,   30,   31,   32,   33,   34,   34],
-//  // PAD_2D_TEST:        [30,   30,   31,   32,   33,   34,   34],
-//  // PAD_2D_TEST:        [30,   30,   31,   32,   33,   34,   34]]
-//  // clang-format on
-//
-//  f.print(llvm::outs());
-//  testFun.print(llvm::outs());
-//
-//  f.erase();
-//  testFun.erase();
-//}
-//
-//TEST_FUNC(test_zip2D) {
-//  int64_t width = 3;
-//  int64_t height = 3;
-//  auto f32Type = FloatType::getF32(&globalContext());
-//
-//  auto f = makeFunction("zip2D", {},
-//                        {MemRefType::get({height, width}, f32Type, {}, 0),
-//                         MemRefType::get({height, width}, f32Type, {}, 0),
-//                         MemRefType::get({height, width}, f32Type, {}, 0)});
-//
-//  OpBuilder builder(f.getBody());
-//  ScopedContext scope(builder, f.getLoc());
-//
-//  Value inputA = f.getArgument(0);
-//  Value inputB = f.getArgument(1);
-//  Value output = f.getArgument(2);
-//
-//  //  Value inA = in(inputA, arrayType(height, arrayType(width,
-//  //  scalarF32Type()))); Value inB = in(inputA, arrayType(height,
-//  //  arrayType(width, scalarF32Type())));
-//
-//  makeRiseProgram(inputA, inputB, output, [&](Value inA, Value inB) {
-//    Value zipped = zip2D(inA, inB);
-//    return mapSeq2D(
-//        scalarF32Type(),
-//        [&](Value tuple) {
-//          return embed2(scalarF32Type(), ValueRange{fst(tuple), snd(tuple)},
-//                        [&](Value fst, Value snd) { return fst + snd; });
-//        },
-//        zipped);
-//  });
-//
-//  //  out(output, result);
-//  std_ret();
-//
-//  // generate test
-//  auto testFun = makeFunction("zip2D_test", {}, {});
-//  OpBuilder test_builder(testFun.getBody());
-//  ScopedContext test_scope(test_builder, testFun.getLoc());
-//  mlir::edsc::highlevel::generateTest(2, {height, width}, {height, width},
-//                                      {height, width}, f);
-//  std_ret();
-//
-//  // clang-format off
-//  // ZIP_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [3, 3] strides = [3, 1] data =
-//  // ZIP_2D_TEST:       {{\[\[}}1,   2,   3],
-//  // ZIP_2D_TEST:        [4,   5,   6],
-//  // ZIP_2D_TEST:        [7,   8,   9]]
-//  // ZIP_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [3, 3] strides = [3, 1] data =
-//  // ZIP_2D_TEST:       {{\[\[}}1,   1,   1],
-//  // ZIP_2D_TEST:        [1,   1,   1],
-//  // ZIP_2D_TEST:        [1,   1,   1]]
-//  // ZIP_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [3, 3] strides = [3, 1] data =
-//  // ZIP_2D_TEST:       {{\[\[}}2,   3,   4],
-//  // ZIP_2D_TEST:        [5,   6,   7],
-//  // ZIP_2D_TEST:        [8,   9,   10]]
-//  // clang-format on
-//
-//  f.print(llvm::outs());
-//  testFun.print(llvm::outs());
-//
-//  f.erase();
-//  testFun.erase();
-//}
+  f.print(llvm::outs());
+  testFun.print(llvm::outs());
 
-// TEST_FUNC(test_makeRiseProgramOneArg) {
-//  auto f32Type = FloatType::getF32(&globalContext());
-//  auto f = makeFunction("makeRiseProgramOneArg", {},
-//                        {MemRefType::get({9}, f32Type, {}, 0),
-//                         MemRefType::get({9}, f32Type, {}, 0)});
-//  OpBuilder builder(f.getBody());
-//  ScopedContext scope(builder, f.getLoc());
-//
-//  makeRiseProgram(f.getArgument(0), f.getArgument(1), [&](Value input) {
-//    return mapSeq(
-//        scalarF32Type(),
-//        [](Value elem) {
-//          return embed1(scalarF32Type(), {elem},
-//                        [](Value elem) { return elem + elem - elem; });
-//        },
-//        input);
-//  });
-//  std_ret();
-//
-//  f.print(llvm::outs());
-//  f.erase();
-//}
-//
-// TEST_FUNC(test_makeRiseProgramTwoArgs) {
-//  auto f32Type = FloatType::getF32(&globalContext());
-//  auto f = makeFunction("makeRiseProgramTwoArgs", {},
-//                        {MemRefType::get({9}, f32Type, {}, 0),
-//                         MemRefType::get({9}, f32Type, {}, 0),
-//                         MemRefType::get({9}, f32Type, {}, 0)});
-//  OpBuilder builder(f.getBody());
-//  ScopedContext scope(builder, f.getLoc());
-//
-//  makeRiseProgram(f.getArgument(0), f.getArgument(1), f.getArgument(2),
-//                  [&](Value input0, Value input1) {
-//                    return mapSeq(
-//                        scalarF32Type(),
-//                        [](Value tuple) {
-//                          return embed2(
-//                              scalarF32Type(), {fst(tuple), snd(tuple)},
-//                              [](Value fst, Value snd) { return fst + snd; });
-//                        },
-//                        zip(input0, input1));
-//                  });
-//
-//  makeRiseProgram(
-//      f.getArgument(0), f.getArgument(1), f.getArgument(1), f.getArgument(2),
-//      [&](Value input0, Value input1, Value input2) {
-//        return mapSeq(
-//            scalarF32Type(),
-//            [](Value tuple) {
-//              return embed2(scalarF32Type(), {fst(tuple), snd(tuple)},
-//                            [](Value fst, Value snd) { return fst + snd; });
-//            },
-//            zip(input0, input1));
-//      });
-//
-//  std_ret();
-//  f.print(llvm::outs());
-//  f.erase();
-//}
+  f.erase();
+  testFun.erase();
+}
+
+TEST_FUNC(test_slide2d) {
+  int64_t M = 7;
+  int64_t N = 5;
+  int slideOuter = 5;
+  int slideInner = 3;
+  auto f32Type = FloatType::getF32(&globalContext());
+
+  auto f = makeFunction("slide2D", {},
+                        {MemRefType::get({M, N}, f32Type, {}, 0),
+                         MemRefType::get({M - 2, N - 4, slideOuter, slideInner},
+                                         f32Type, {}, 0)});
+
+  OpBuilder builder(f.getBody());
+  ScopedContext scope(builder, f.getLoc());
+
+  Value input = f.getArgument(0);
+  Value output = f.getArgument(1);
+
+  makeRiseProgram(output, input)([&](Value input) {
+    Value slizzled = slide2D(natType(slideOuter), natType(1),
+                             natType(slideInner), natType(1), input);
+
+    return mapSeq2D(
+        array2DType(slideOuter, slideInner, scalarF32Type()),
+        [&](Value arr2D) {
+          return mapSeq2D(
+              scalarF32Type(),
+              [&](Value elem) {
+                return embed1(scalarF32Type(), elem, [&](Value elem) {
+                  Value cst = std_constant_float(llvm::APFloat(0.0f), f32Type);
+                  return elem + cst;
+                });
+              },
+              arr2D);
+        },
+        slizzled);
+  });
+
+  std_ret();
+
+  // generate test
+  auto testFun = makeFunction("slide2D_test", {}, {});
+  OpBuilder test_builder(testFun.getBody());
+  ScopedContext test_scope(test_builder, testFun.getLoc());
+
+  makeRiseTest(f, {M - 2, N - 4, slideOuter, slideInner},
+               getFilledMemRef({M, N}));
+  std_ret();
+
+  f.print(llvm::outs());
+  testFun.print(llvm::outs());
+  testFun.erase();
+  f.erase();
+}
+
+TEST_FUNC(test_pad2d) {
+  int64_t width = 5;
+  int64_t height = 7;
+  int padInnerl = 1;
+  int padInnerr = 1;
+  int padOuterl = 2;
+  int padOuterr = 2;
+  int64_t outWidth = padInnerl + width + padInnerr;
+  int64_t outHeight = padOuterl + height + padOuterr;
+
+  auto f32Type = FloatType::getF32(&globalContext());
+
+  auto f =
+      makeFunction("pad2D", {},
+                   {MemRefType::get({height, width}, f32Type, {}, 0),
+                    MemRefType::get({outHeight, outWidth}, f32Type, {}, 0)});
+
+  OpBuilder builder(f.getBody());
+  ScopedContext scope(builder, f.getLoc());
+
+  Value input = f.getArgument(0);
+  Value output = f.getArgument(1);
+
+  //  Value inn = in(input, arrayType(height, arrayType(width,
+  //  scalarF32Type())));
+
+  makeRiseProgram(output, input)([&](Value input) {
+    Value padded = pad2D(natType(padOuterl), natType(padOuterr),
+                         natType(padInnerl), natType(padInnerr), input);
+
+    ArrayType paddedType = padded.getType().dyn_cast<ArrayType>();
+    ArrayType innerType = paddedType.getElementType().dyn_cast<ArrayType>();
+
+    return mapSeq2D(
+        scalarF32Type(),
+        [&](Value elem) {
+          return embed1(scalarF32Type(), elem, [&](Value elem) {
+            Value cst = std_constant_float(llvm::APFloat(0.0f), f32Type);
+            return elem + cst;
+          });
+        },
+        padded);
+  });
+
+  //  out(output, mapped);
+
+  std_ret();
+
+  // generate test
+  auto testFun = makeFunction("pad2D_test", {}, {});
+  OpBuilder test_builder(testFun.getBody());
+  ScopedContext test_scope(test_builder, testFun.getLoc());
+
+  makeRiseTest(f, {outHeight, outWidth}, getFilledMemRef({height, width}));
+
+  //  mlir::edsc::highlevel::generateTest(2, {height, width}, {outHeight,
+  //  outWidth},
+  //                                      f);
+  std_ret();
+  // clang-format off
+  // PAD_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [7, 5] strides = [5, 1] data =
+  // PAD_2D_TEST:       {{\[\[}}0,   1,   2,   3,   4],
+  // PAD_2D_TEST:        [5,   6,   7,   8,   9],
+  // PAD_2D_TEST:        [10,   11,   12,   13,   14],
+  // PAD_2D_TEST:        [15,   16,   17,   18,   19],
+  // PAD_2D_TEST:        [20,   21,   22,   23,   24],
+  // PAD_2D_TEST:        [25,   26,   27,   28,   29],
+  // PAD_2D_TEST:        [30,   31,   32,   33,   34]]
+  // PAD_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [11, 7] strides = [7, 1] data =
+  // PAD_2D_TEST:       {{\[\[}}0,   0,   1,   2,   3,   4,   4],
+  // PAD_2D_TEST:        [0,   0,   1,   2,   3,   4,   4],
+  // PAD_2D_TEST:        [0,   0,   1,   2,   3,   4,   4],
+  // PAD_2D_TEST:        [5,   5,   6,   7,   8,   9,   9],
+  // PAD_2D_TEST:        [10,   10,   11,   12,   13,   14,   14],
+  // PAD_2D_TEST:        [15,   15,   16,   17,   18,   19,   19],
+  // PAD_2D_TEST:        [20,   20,   21,   22,   23,   24,   24],
+  // PAD_2D_TEST:        [25,   25,   26,   27,   28,   29,   29],
+  // PAD_2D_TEST:        [30,   30,   31,   32,   33,   34,   34],
+  // PAD_2D_TEST:        [30,   30,   31,   32,   33,   34,   34],
+  // PAD_2D_TEST:        [30,   30,   31,   32,   33,   34,   34]]
+  // clang-format on
+
+  f.print(llvm::outs());
+  testFun.print(llvm::outs());
+
+  f.erase();
+  testFun.erase();
+}
+
+TEST_FUNC(test_zip2D) {
+  int64_t width = 3;
+  int64_t height = 3;
+  auto f32Type = FloatType::getF32(&globalContext());
+
+  auto f = makeFunction("zip2D", {},
+                        {MemRefType::get({height, width}, f32Type, {}, 0),
+                         MemRefType::get({height, width}, f32Type, {}, 0),
+                         MemRefType::get({height, width}, f32Type, {}, 0)});
+
+  OpBuilder builder(f.getBody());
+  ScopedContext scope(builder, f.getLoc());
+
+  Value inputA = f.getArgument(0);
+  Value inputB = f.getArgument(1);
+  Value output = f.getArgument(2);
+
+  makeRiseProgram(output, inputA, inputB)([&](Value inA, Value inB) {
+    Value zipped = zip2D(inA, inB);
+    return mapSeq2D(
+        scalarF32Type(),
+        [&](Value tuple) {
+          return embed2(scalarF32Type(), ValueRange{fst(tuple), snd(tuple)},
+                        [&](Value fst, Value snd) { return fst * snd; });
+        },
+        zipped);
+  });
+  std_ret();
+
+  // generate test
+  auto testFun = makeFunction("zip2D_test", {}, {});
+  OpBuilder test_builder(testFun.getBody());
+  ScopedContext test_scope(test_builder, testFun.getLoc());
+
+  Value filledA = getFilledMemRef({height, width});
+  Value filledB = getFilledMemRef({height, width});
+  makeRiseTest(f, {height, width}, filledA, filledB);
+  std_ret();
+
+  // clang-format off
+  // ZIP_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [3, 3] strides = [3, 1] data =
+  // ZIP_2D_TEST:       {{\[\[}}0,   1,   2],
+  // ZIP_2D_TEST:        [3,  4,   5],
+  // ZIP_2D_TEST:        [6,  7,   8]]
+  // ZIP_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [3, 3] strides = [3, 1] data =
+  // ZIP_2D_TEST:       {{\[\[}}0,   1,   2],
+  // ZIP_2D_TEST:        [3,  4,   5],
+  // ZIP_2D_TEST:        [6,  7,   8]]
+  // ZIP_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [3, 3] strides = [3, 1] data =
+  // ZIP_2D_TEST:       {{\[\[}}0,   1,   4],
+  // ZIP_2D_TEST:        [9,   16,   25],
+  // ZIP_2D_TEST:        [36,   49,   64]]
+  // clang-format on
+
+  f.print(llvm::outs());
+  testFun.print(llvm::outs());
+
+  f.erase();
+  testFun.erase();
+}
 
 int main() {
   RUN_TESTS();

--- a/mlir/test/lib/Dialect/Rise/rise_highlevel_test.cpp
+++ b/mlir/test/lib/Dialect/Rise/rise_highlevel_test.cpp
@@ -231,6 +231,79 @@ TEST_FUNC(test_conv2) {
   f.erase();
   testFun.erase();
 }
+//
+//TEST_FUNC(test_conv_tf) {
+//  int64_t width = 7;
+//  int64_t height = 7;
+//  int64_t kernelWidth = 3;
+//  int64_t kernelHeight = 3;
+//  auto f32Type = FloatType::getF32(&globalContext());
+//
+//  auto f = makeFunction("conv2D", {},
+//                        {MemRefType::get({1, height, width, 1}, f32Type, {}, 0),
+//                         MemRefType::get({kernelHeight, kernelWidth, 1, 1}, f32Type, {}, 0),
+//                         MemRefType::get({1, height-2, width-2, 1}, f32Type, {}, 0)});
+//
+//  OpBuilder builder(f.getBody());
+//  ScopedContext scope(builder, f.getLoc());
+//
+//  Value inputArg = f.getArgument(0);
+//  Value kernelArg = f.getArgument(1);
+//  Value output = f.getArgument(2);
+//
+//  Value A = in(inputArg, arrayType(height, arrayType(width, scalarF32Type())));
+//  Value kernel = in(kernelArg, arrayType(kernelHeight, arrayType(kernelWidth, scalarF32Type())));
+//
+//  Value input = in(inputBuffers[0], inputType);
+//  Value kernel = in(inputBuffers[1], kernelType);
+//
+//  Value result = conv2D(A, kernel);
+//  out(output, result);
+//  std_ret();
+//
+//  // generate test
+//  auto testFun = makeFunction("conv2DTF_test", {}, {});
+//  OpBuilder test_builder(testFun.getBody());
+//  ScopedContext test_scope(test_builder, testFun.getLoc());
+//  mlir::edsc::highlevel::generateTest(4, {1, height, width, 1}, {kernelHeight, kernelWidth, 1, 1}, {1, height, width, 1},
+//                                      f);
+//  std_ret();
+//  // clang-format off
+//  // CONV_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [9, 9] strides = [9, 1] data =
+//  // CONV_2D_TEST:       {{\[\[}}1,   2,   3,   4,   5,   6,   7,   8,   9],
+//  // CONV_2D_TEST:        [10,   11,   12,   13,   14,   15,   16,   17,   18],
+//  // CONV_2D_TEST:        [19,   20,   21,   22,   23,   24,   25,   26,   27],
+//  // CONV_2D_TEST:        [28,   29,   30,   31,   32,   33,   34,   35,   36],
+//  // CONV_2D_TEST:        [37,   38,   39,   40,   41,   42,   43,   44,   45],
+//  // CONV_2D_TEST:        [46,   47,   48,   49,   50,   51,   52,   53,   54],
+//  // CONV_2D_TEST:        [55,   56,   57,   58,   59,   60,   61,   62,   63],
+//  // CONV_2D_TEST:        [64,   65,   66,   67,   68,   69,   70,   71,   72],
+//  // CONV_2D_TEST:        [73,   74,   75,   76,   77,   78,   79,   80,   81]]
+//  // CONV_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [3, 3] strides = [3, 1] data =
+//  // CONV_2D_TEST:       {{\[\[}}1,   1,   1],
+//  // CONV_2D_TEST:        [1,   1,   1],
+//  // CONV_2D_TEST:        [1,   1,   1]]
+//  // CONV_2D_TEST:       Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [9, 9] strides = [9, 1] data =
+//  // CONV_2D_TEST:       {{\[\[}}39,   45,   54,   63,   72,   81,   90,   99,   105],
+//  // CONV_2D_TEST:        [93,   99,   108,   117,   126,   135,   144,   153,   159],
+//  // CONV_2D_TEST:        [174,   180,   189,   198,   207,   216,   225,   234,   240],
+//  // CONV_2D_TEST:        [255,   261,   270,   279,   288,   297,   306,   315,   321],
+//  // CONV_2D_TEST:        [336,   342,   351,   360,   369,   378,   387,   396,   402],
+//  // CONV_2D_TEST:        [417,   423,   432,   441,   450,   459,   468,   477,   483],
+//  // CONV_2D_TEST:        [498,   504,   513,   522,   531,   540,   549,   558,   564],
+//  // CONV_2D_TEST:        [579,   585,   594,   603,   612,   621,   630,   639,   645],
+//  // CONV_2D_TEST:        [633,   639,   648,   657,   666,   675,   684,   693,   699]]
+//  // clang-format on
+//
+//
+//  f.print(llvm::outs());
+//  testFun.print(llvm::outs());
+//
+//  f.erase();
+//  testFun.erase();
+//}
+
+
 
 TEST_FUNC(build_lower_and_execute_2Dstencil) {
   // A:MxN * B:NxK = C:MxK


### PR DESCRIPTION
- new op `rise.lowering_unit`
- builder for new op
- new highlevel abstraction `makeRiseProgram`, which handles generation of the required rise.in and rise.out ops for a rise program.
- adjusted lowering pass accordingly
- fixed bug when generating a temporary accumulator for a reduction